### PR TITLE
added in reference for n8n wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Feel free to share the repository link in your blog, study notes, or interview p
 * [`docs/interview_questions_2026.md`](./docs/interview_questions_2026.md): deep-dive interview Q&A covering agents, RAG, LLM scaling, production AI, and system design. **(New)**
 * [`docs/resources-and-references.md`](./docs/resources-and-references.md): books, references, and additional interview topics.
 * [`docs/study-pattern.md`](./docs/study-pattern.md): recommended preparation topics, difficulty levels, and study structure.
-* [`ai_genai/`](./ai_genai): GenAI and LLM engineering topics including CrewAI, LangGraph, LangSmith, multi-agent systems, and advanced RAG. **(Expanded)**
+* [`ai_genai/`](./ai_genai): GenAI and LLM engineering topics including n8n, CrewAI, LangGraph, LangSmith, multi-agent systems, and advanced RAG. **(Expanded)**
 * [`classical_ml/`](./classical_ml): classical ML algorithms — time series, clustering, dimensionality reduction, recommender systems, feature engineering.
 * [`mlops/`](./mlops): MLOps topics — MLflow, model serving, feature stores, explainability, data quality, LLM evaluation. **(Expanded)**
 * [`cloud_ml/`](./cloud_ml): cloud ML platforms — AWS SageMaker, Google Vertex AI, Azure ML.
@@ -89,6 +89,7 @@ Use these to turn the repo into a portfolio, not just a reading list:
 * [Multi-Agent Research Assistant](./ai_genai/intro_agent_tool_use.md)
 * [Multi-Model Router](./ai_genai/intro_multi_model_orchestration.md)
 * [Document Understanding System](./ai_genai/intro_multimodal_ai.md)
+* [AI Workflow Automation with n8n](./ai_genai/intro_n8n.md)
 * [Eval Pipeline](./mlops/intro_evaluation_guardrails.md)
 * [CI/CD for AI App](./mlops/intro_llmops_mlops_engineering.md)
 * [Scalable AI API](./system_design/intro_backend_ai_system_design.md)
@@ -110,6 +111,8 @@ Core topics:
 * [Multi-Model & AI Orchestration](./ai_genai/intro_multi_model_orchestration.md) **(New)**
 * [Multimodal AI](./ai_genai/intro_multimodal_ai.md) **(New)**
 * [CrewAI](./ai_genai/intro_crewai.md) **(New)**
+* [n8n - AI Workflow Automation](./ai_genai/intro_n8n.md) **(New)**
+* [n8n - Advanced AI Workflows](./ai_genai/intro_n8n_advanced.md) **(New)**
 * [LangGraph](./ai_genai/intro_langgraph.md) **(New)**
 * [LangSmith — Observability & Evaluation](./ai_genai/intro_langsmith.md) **(New)**
 * [MCP](./ai_genai/intro_mcp.md)

--- a/ai_genai/intro_agent_tool_use.md
+++ b/ai_genai/intro_agent_tool_use.md
@@ -65,6 +65,7 @@ Real systems need stable state transitions, audit logs, and explicit checkpoints
 | LangGraph | Stateful graph orchestration for agents | Production agent flows with branches and recovery |
 | AutoGen | Multi-agent conversation framework | Research-style agent collaboration experiments |
 | CrewAI | Role-based multi-agent task coordination | Lightweight multi-agent business workflows |
+| n8n | Visual workflow automation for triggers, approvals, and integrations | Operational AI workflows and business automation |
 | MCP | Standardized tool and context protocol | Secure tool integration across apps and agents |
 
 ---
@@ -82,7 +83,7 @@ Real systems need stable state transitions, audit logs, and explicit checkpoints
 
 - Goal: Automate internal repetitive workflows like ticket triage or runbook generation.
 - Key components: workflow triggers, tool registry, approval gates, retry logic, audit logs.
-- Suggested tech stack: FastAPI, LangGraph, Postgres, Redis.
+- Suggested tech stack: n8n or FastAPI, LangGraph, Postgres, Redis.
 - Difficulty: Advanced.
 
 ### AI coding assistant
@@ -148,6 +149,7 @@ planner-executor-agent/
 ## Related Topics
 
 - [Multi-Agent Systems](./intro_multi_agent_systems.md)
+- [n8n](./intro_n8n.md)
 - [LangGraph](./intro_langgraph.md)
 - [MCP](./intro_mcp.md)
 - [Backend & System Design for AI](../system_design/intro_backend_ai_system_design.md)

--- a/ai_genai/intro_agentic_ai.md
+++ b/ai_genai/intro_agentic_ai.md
@@ -558,6 +558,7 @@ Research the current state of vector databases in 2026:
 |-----------|----------|-------------|
 | **LangGraph** | Python | Stateful multi-agent graphs |
 | **CrewAI** | Python | Role-based agent crews |
+| **n8n** | TypeScript | Visual workflow automation with AI integrations |
 | **AutoGen** | Python | Multi-agent conversations (Microsoft) |
 | **Claude Code** | TypeScript | Agentic coding assistant |
 | **Composio** | Python | 250+ tool integrations for agents |
@@ -589,6 +590,7 @@ Research the current state of vector databases in 2026:
 | Topic | Why It's Related |
 |-------|-----------------|
 | [RAG](./intro_rag.md) | Agentic RAG combines agents with retrieval |
+| [n8n](./intro_n8n.md) | n8n is useful when agent workflows need triggers, approvals, and SaaS integrations |
 | [MCP](./intro_mcp.md) | Model Context Protocol is the standard tool interface for agents |
 | [LangChain](./intro_langchain.md) | LangGraph is the leading framework for agentic workflows |
 | [LLMOps](./intro_llmops.md) | Monitoring and evaluating agent reliability in production |

--- a/ai_genai/intro_n8n.md
+++ b/ai_genai/intro_n8n.md
@@ -1,0 +1,266 @@
+# n8n - AI Workflow Automation Guide
+
+## What is n8n?
+
+**n8n** is a workflow automation platform that lets you connect APIs, databases, webhooks, queues, and AI services using a visual node-based editor.
+
+It is especially useful when you need to:
+
+- automate repetitive business workflows,
+- connect LLMs to external systems,
+- build human approval flows,
+- trigger AI jobs from forms, Slack, email, or webhooks,
+- ship internal AI tooling without writing a full orchestration backend first.
+
+In interviews, n8n usually comes up as a **low-code workflow orchestrator** that sits between product automation tools and code-first agent frameworks.
+
+---
+
+## Core Mental Model
+
+Think of n8n as:
+
+```text
+Trigger -> Workflow -> Nodes -> External Systems -> Output / Next Action
+```
+
+Each workflow is a graph of nodes:
+
+- **Trigger nodes** start execution.
+- **Action nodes** call APIs or perform logic.
+- **AI nodes** invoke models, prompts, tools, or memory-backed flows.
+- **Logic nodes** branch, merge, filter, retry, and transform data.
+- **Human review steps** pause or redirect execution when needed.
+
+---
+
+## Core Concepts
+
+| Concept | What it means |
+|---------|----------------|
+| **Workflow** | The end-to-end automation graph |
+| **Node** | One unit of work such as HTTP request, database query, AI call, or condition |
+| **Trigger** | Event that starts the workflow: webhook, cron, Slack message, form submit, queue event |
+| **Execution** | A single run of a workflow |
+| **Credential** | Stored auth for external services |
+| **Expression** | Dynamic values computed from previous nodes |
+| **Webhook** | HTTP endpoint that can start a flow or receive callbacks |
+| **Queue mode** | Scaled execution model using workers and a queue backend |
+
+---
+
+## Where n8n Fits in an AI Stack
+
+| Layer | Typical Tools | n8n's role |
+|------|---------------|------------|
+| UI / event source | Slack, forms, email, CRM, webhook | Receives triggers and routes work |
+| AI orchestration | LangGraph, custom Python, MCP tools, prompt pipelines | Can call these systems or host lightweight orchestration directly |
+| Data / storage | Postgres, Redis, S3, vector DBs | Reads and writes operational context |
+| Human review | Slack approvals, dashboards, ticketing systems | Inserts approval and escalation steps |
+| Delivery | Email, CRM updates, issue trackers, chatops | Pushes outputs into business systems |
+
+The practical takeaway:
+
+- Use **n8n** when workflow automation and integration breadth matter.
+- Use **LangGraph** or code-first orchestration when complex state machines, custom control flow, or deep engineering control matter.
+- Use both together when you want visual business automation around a code-first agent core.
+
+---
+
+## Common AI Use Cases
+
+### 1. Lead enrichment workflow
+
+```text
+Webhook -> Validate payload -> Search CRM -> Call LLM for summary
+        -> Enrich from external APIs -> Score lead -> Route to sales rep
+        -> Notify Slack
+```
+
+### 2. Support ticket triage
+
+```text
+Zendesk trigger -> Classify urgency -> Retrieve KB context
+                 -> Draft response -> Human approval for high-risk tickets
+                 -> Post reply -> Log metrics
+```
+
+### 3. Content operations
+
+```text
+Notion page created -> Generate summary -> Create social draft
+                     -> Human review -> Publish -> Update tracking sheet
+```
+
+### 4. Internal AI assistant back office
+
+```text
+User request -> n8n webhook -> auth check -> call agent backend
+             -> save transcript -> create follow-up tasks -> notify channel
+```
+
+---
+
+## n8n vs Other Workflow Tools
+
+| Tool | Best For | Strength | Weakness |
+|------|----------|----------|----------|
+| **n8n** | AI-enabled business workflows and app integrations | Visual builder plus custom logic flexibility | Very complex stateful reasoning is still easier in code |
+| **LangGraph** | Stateful AI agents and multi-step reasoning | Explicit control over loops, branches, and memory | More engineering effort |
+| **Apache Airflow** | Scheduled data and batch pipelines | Strong DAG-based scheduling for data workloads | Less natural for app automation and human-facing triggers |
+| **Zapier** | Simple SaaS automation | Fastest for non-technical teams | Less engineering control |
+| **Temporal** | Long-running durable workflows | Strong execution guarantees and recovery | Heavier engineering and ops overhead |
+
+---
+
+## Example: AI Ticket Triage in n8n
+
+### Flow
+
+```text
+Zendesk Trigger
+  -> Normalize ticket text
+  -> Classify issue type with LLM
+  -> Retrieve relevant FAQ / docs
+  -> Draft response
+  -> IF priority = high
+       -> Slack approval
+     ELSE
+       -> Send draft automatically
+  -> Write audit log to database
+```
+
+### What interviewers care about
+
+- where the trigger comes from,
+- how credentials are managed,
+- how you prevent duplicate processing,
+- where human approval is required,
+- how you monitor failures and retries,
+- whether the LLM is allowed to act directly or only suggest actions.
+
+---
+
+## Production Design Considerations
+
+### 1. Idempotency
+
+If the same webhook arrives twice, the workflow should not create duplicate tickets, emails, or downstream actions.
+
+Use:
+
+- event IDs,
+- database dedupe keys,
+- "upsert" style writes,
+- replay-safe workflow design.
+
+### 2. Human-in-the-loop
+
+Do not fully automate high-risk actions such as:
+
+- deleting records,
+- issuing refunds,
+- sending legal or compliance responses,
+- changing production infrastructure.
+
+Insert approval checkpoints through Slack, email, or an internal review queue.
+
+### 3. Error handling
+
+Workflows should define:
+
+- retry policy,
+- timeout behavior,
+- dead-letter or failure queue pattern,
+- notification path for operators.
+
+### 4. Secrets and credentials
+
+Keep credentials in the platform credential store, not inline in nodes or prompts.
+
+### 5. Auditability
+
+For AI-assisted business flows, log:
+
+- input payload,
+- prompt or task version,
+- model output,
+- human approvals,
+- downstream actions taken.
+
+### 6. Separation of concerns
+
+n8n should often coordinate the workflow while heavier reasoning or proprietary logic runs in:
+
+- a Python backend,
+- a FastAPI service,
+- a LangGraph agent service,
+- or internal tools exposed via API.
+
+---
+
+## When to Use n8n
+
+**Use n8n when:**
+
+- you need many SaaS integrations quickly,
+- business teams need visibility into the automation,
+- workflows are event-driven and operational,
+- you want fast iteration on AI-enhanced internal tools,
+- human approval and routing are part of the process.
+
+**Avoid using n8n alone when:**
+
+- the workflow needs advanced graph-state control,
+- you need long-running agent memory with custom recovery logic,
+- you require deep custom testing around reasoning loops,
+- the critical path depends on complex code-first orchestration.
+
+In those cases, use n8n as the outer automation layer and call a code-first backend.
+
+---
+
+## Interview Questions
+
+**Q1: What is n8n and how is it different from LangGraph?**
+
+> n8n is a node-based workflow automation platform focused on integrating business systems, triggers, approvals, and API calls. LangGraph is a code-first framework for stateful AI agent orchestration. n8n is better for operational automation; LangGraph is better for complex reasoning workflows.
+
+**Q2: When would you choose n8n over Airflow?**
+
+> Choose n8n for event-driven application workflows, SaaS integrations, webhooks, approvals, and AI-powered back-office automation. Choose Airflow for scheduled data pipelines, batch jobs, and data platform orchestration.
+
+**Q3: What are the risks of using n8n in AI workflows?**
+
+> The main risks are poor idempotency, hidden credential sprawl, weak approval boundaries, limited testing of complex logic, and letting the LLM trigger unsafe downstream actions. Mitigate with dedupe keys, credential isolation, approval gates, and service-layer validation.
+
+**Q4: How would you productionize an n8n workflow?**
+
+> Add queue-based execution, structured logging, retries, alerting, API-level validation, approval checkpoints, external state storage, and clear ownership for secrets and deployments.
+
+**Q5: Can n8n be part of an agent architecture?**
+
+> Yes. It often works well as the outer orchestration layer that handles triggers, routing, notifications, approvals, and integration steps, while a code-first agent backend handles planning, tool selection, and reasoning.
+
+**Q6: What is the main tradeoff of low-code AI orchestration?**
+
+> Speed and integration breadth improve, but very complex control flow, fine-grained testing, and custom runtime behavior are easier to manage in code.
+
+---
+
+## Related Topics
+
+| Topic | Why it matters |
+|------|----------------|
+| [Agentic AI](./intro_agentic_ai.md) | n8n can orchestrate AI agents and approval flows |
+| [Agent Systems & Tool Use](./intro_agent_tool_use.md) | n8n is often used to wrap tool-enabled AI workflows |
+| [LangGraph](./intro_langgraph.md) | Strong comparison point for code-first orchestration |
+| [MCP](./intro_mcp.md) | MCP tools can sit behind APIs that n8n workflows call |
+| [Apache Airflow](../data_engineering/intro_apache_airflow.md) | Useful contrast between app automation and data orchestration |
+
+---
+
+## References
+
+- [n8n official site](https://n8n.io/)
+- [n8n documentation](https://docs.n8n.io/)

--- a/ai_genai/intro_n8n_advanced.md
+++ b/ai_genai/intro_n8n_advanced.md
@@ -1,0 +1,336 @@
+# n8n - Advanced AI Workflows and Production Patterns
+
+## Why an Advanced n8n Guide?
+
+The introductory guide explains what n8n is and when to use it. This page focuses on the higher-signal interview topics:
+
+- scaling execution,
+- combining n8n with agent backends,
+- human approval and audit design,
+- RAG and AI workflow patterns,
+- reliability and operational guardrails.
+
+---
+
+## Advanced Architecture Pattern
+
+For serious AI systems, a strong pattern is:
+
+```text
+External Trigger
+  -> n8n workflow
+  -> auth / validation / routing
+  -> code-first AI service
+  -> business approval / notification steps
+  -> downstream system updates
+```
+
+This keeps responsibilities clear:
+
+- **n8n** handles workflow orchestration and integrations,
+- **AI backend** handles reasoning and model-specific logic,
+- **databases and queues** handle durability and replay safety,
+- **humans** remain in the loop for high-risk decisions.
+
+---
+
+## Pattern 1: n8n as the Outer Control Plane
+
+This is usually the cleanest production design.
+
+### Example
+
+```text
+Slack trigger
+  -> Parse request
+  -> Check user permissions
+  -> Call internal agent API
+  -> Receive structured result
+  -> If confidence < threshold -> send for human review
+  -> Else update Jira and notify Slack
+```
+
+### Why this works
+
+- Business users can see and edit the workflow.
+- Engineers keep complex reasoning in code.
+- Approval logic stays explicit.
+- Operational integrations remain easy to change.
+
+---
+
+## Pattern 2: Human-in-the-Loop Approval Chains
+
+AI systems should not blindly execute expensive or risky actions.
+
+### Example approval flow
+
+```text
+Incoming request
+  -> LLM draft
+  -> Risk classification
+  -> IF low risk
+       -> auto-send
+     ELSE
+       -> manager approval
+       -> compliance approval
+       -> execute action
+```
+
+### Good interview points
+
+- approvals should be explicit and traceable,
+- approvers need enough context to review quickly,
+- the system should support timeout, rejection, and escalation paths,
+- every approval event should be logged.
+
+---
+
+## Pattern 3: RAG Pipeline with n8n
+
+n8n can coordinate a light RAG workflow:
+
+```text
+Webhook -> normalize query -> embed query -> vector search API
+        -> rerank top documents -> build prompt -> call LLM
+        -> return answer -> store trace
+```
+
+### Where n8n is enough
+
+- simple internal assistants,
+- support automation,
+- lightweight document Q&A over a few systems,
+- demos and MVPs.
+
+### Where code-first RAG wins
+
+- custom chunking and indexing strategies,
+- hybrid retrieval and advanced reranking,
+- evaluation pipelines,
+- multi-step retrieval,
+- tight latency optimization.
+
+Use n8n to orchestrate the workflow and call specialized retrieval services when the RAG stack becomes complex.
+
+---
+
+## Pattern 4: Queue-Based Scaling
+
+For higher traffic, direct synchronous execution becomes fragile.
+
+### Better model
+
+```text
+Webhook -> validate -> enqueue job
+       -> worker picks up task
+       -> executes workflow
+       -> writes result
+       -> sends callback / notification
+```
+
+### Why queues matter
+
+- absorb traffic spikes,
+- isolate slow downstream systems,
+- improve retry behavior,
+- avoid request timeouts,
+- scale workers horizontally.
+
+Key interview point:
+
+> Visual workflows are convenient, but production reliability still depends on standard distributed-systems patterns such as queues, retries, backpressure, and idempotency.
+
+---
+
+## Pattern 5: Safe Tool-Calling for Business Automation
+
+If an LLM proposes actions inside a workflow, never trust those actions directly.
+
+Use this pattern:
+
+```text
+LLM suggests action -> schema validation -> policy check -> optional human approval -> execute
+```
+
+Examples of policy checks:
+
+- user is authorized,
+- budget is below threshold,
+- target record exists,
+- required fields are present,
+- action type is allowed for this workflow.
+
+This matters because the model should recommend actions, not define the final policy boundary.
+
+---
+
+## n8n vs LangGraph vs Airflow - Advanced Comparison
+
+| Dimension | n8n | LangGraph | Airflow |
+|-----------|-----|-----------|---------|
+| Primary use | Business workflow automation | Stateful AI orchestration | Scheduled data pipelines |
+| Control flow depth | Medium | High | Medium |
+| Human approvals | Strong fit | Possible but custom | Usually externalized |
+| App integrations | Strong | Moderate | Moderate |
+| Batch scheduling | Basic to moderate | Custom | Strong |
+| Agent loops and memory | Limited compared to code-first systems | Excellent | Poor fit |
+| Non-technical visibility | High | Low | Medium |
+| Best production role | Outer automation layer | AI reasoning core | Data platform scheduler |
+
+---
+
+## Failure Modes
+
+### 1. Workflow sprawl
+
+Many small visual workflows become hard to govern.
+
+Mitigation:
+
+- naming conventions,
+- owners per workflow,
+- environment separation,
+- change review process,
+- shared sub-workflow patterns.
+
+### 2. Hidden state
+
+State gets spread across nodes, expressions, webhook payloads, and external systems.
+
+Mitigation:
+
+- keep canonical state in a database,
+- pass explicit IDs between steps,
+- keep prompts and business rules versioned.
+
+### 3. Unsafe automation
+
+The workflow auto-executes AI output without validation.
+
+Mitigation:
+
+- strict schemas,
+- policy checks,
+- approval steps,
+- sandboxing of high-risk actions.
+
+### 4. Retry amplification
+
+A failed downstream system causes repeated duplicate side effects.
+
+Mitigation:
+
+- idempotency keys,
+- upserts,
+- dedupe tables,
+- dead-letter handling.
+
+### 5. Weak observability
+
+Teams see workflow success/failure but cannot debug model behavior.
+
+Mitigation:
+
+- log prompt version,
+- log model name and latency,
+- store intermediate outputs,
+- connect to evaluation and tracing systems.
+
+---
+
+## Suggested Production Stack
+
+### Lightweight AI automation
+
+- n8n for triggers and workflow routing
+- OpenAI / Anthropic API for generation
+- Postgres for audit logs
+- Slack for approval
+- Redis for short-lived state or queue support
+
+### More robust AI platform
+
+- n8n for business automation layer
+- FastAPI or Node backend for custom logic
+- LangGraph for agent reasoning
+- Postgres plus object storage for durable state
+- vector DB for retrieval
+- LangSmith or internal tracing for observability
+
+---
+
+## System Design Example
+
+### Design an AI-driven customer escalation workflow
+
+**Requirements**
+
+- Trigger from support platform
+- Draft reply in under 10 seconds
+- Require human approval for legal, refund, or compliance cases
+- Save full audit trail
+- Notify Slack and update CRM automatically
+
+**High-level design**
+
+```text
+Support event
+  -> n8n trigger
+  -> classify request type
+  -> retrieve customer/account context
+  -> call LLM or agent backend
+  -> risk scoring
+  -> IF low risk -> send reply
+     IF medium/high risk -> approval queue
+  -> update CRM
+  -> log full execution
+```
+
+**Tradeoffs**
+
+- synchronous response vs async queue,
+- direct LLM call vs internal agent API,
+- faster automation vs stricter human review,
+- simple workflow visibility vs deeper custom code.
+
+---
+
+## Advanced Interview Questions
+
+**Q1: How would you use n8n in a production agent system without over-relying on low-code logic?**
+
+> Keep n8n as the orchestration shell for triggers, approvals, and integrations. Move reasoning-heavy logic, retrieval logic, and safety-critical policy enforcement into a tested backend service.
+
+**Q2: What are the main scaling limits of visual AI workflows?**
+
+> The limits are usually around hidden complexity, weak versioning discipline, retry side effects, and difficulty testing advanced stateful logic. The answer is not to abandon n8n entirely, but to separate visual orchestration from code-first intelligence.
+
+**Q3: How do you make n8n workflows safe for AI-driven actions?**
+
+> Validate every model output against schemas, run application-side policy checks, add approval gates for risky actions, log everything, and design the workflow to be replay-safe.
+
+**Q4: How would you compare n8n and LangGraph in an interview?**
+
+> n8n optimizes for operational automation and integrations. LangGraph optimizes for deterministic graph control, memory, loops, and agent behavior. n8n is a great wrapper around business processes; LangGraph is stronger inside the AI reasoning core.
+
+**Q5: When should n8n call a separate retrieval or agent service instead of handling everything directly?**
+
+> Once the workflow needs custom retrieval ranking, complex memory, advanced evaluation, or non-trivial branching and recovery logic, the AI part should move into a dedicated service.
+
+---
+
+## Related Topics
+
+- [n8n Intro Guide](./intro_n8n.md)
+- [LangGraph](./intro_langgraph.md)
+- [Agentic AI](./intro_agentic_ai.md)
+- [LLMOps](./intro_llmops.md)
+- [Apache Airflow](../data_engineering/intro_apache_airflow.md)
+
+---
+
+## References
+
+- [n8n official site](https://n8n.io/)
+- [n8n documentation](https://docs.n8n.io/)

--- a/data_engineering/intro_apache_airflow.md
+++ b/data_engineering/intro_apache_airflow.md
@@ -31,6 +31,7 @@ Airflow defines this as a **DAG** (Directed Acyclic Graph) in Python.
 | **Dagster** | Asset-centric, typed | Data assets, lineage, testing |
 | **Mage** | Notebook-style | Data engineers who love notebooks |
 | **Temporal** | Workflow engine | Long-running, stateful workflows |
+| **n8n** | Visual workflow automation | App integrations, webhooks, approval flows, operational AI workflows |
 
 ---
 

--- a/docs/2026-additional-questions.md
+++ b/docs/2026-additional-questions.md
@@ -74,3 +74,6 @@ A strong answer is not "just use a better prompt." It should mention grounding w
 
 #### 25) What 2026 topics are most likely to appear in ML engineer interviews?
 The highest-probability modern topics are RAG design, LLM evaluation, embeddings, vector search, reranking, prompt injection, tool or function calling, agent orchestration, fine-tuning tradeoffs, inference optimization, monitoring, and AI system design under latency and cost constraints.
+
+#### 26) When would you use n8n instead of LangGraph or Airflow?
+Use n8n when the main problem is event-driven workflow automation across SaaS tools, APIs, approvals, and AI calls. Use LangGraph when you need code-first control over stateful agent behavior, loops, and complex branching. Use Airflow when the primary workload is scheduled data or batch pipeline orchestration. In many production systems, n8n handles the outer business workflow while LangGraph or a custom backend handles the reasoning-heavy AI core.

--- a/docs/2026-interview-roadmap.md
+++ b/docs/2026-interview-roadmap.md
@@ -5,6 +5,7 @@ For 2026 Machine Learning Engineer and AI Engineer interviews, the most common e
 * Classical machine learning fundamentals: bias vs variance, metrics, feature engineering, regularization, cross-validation.
 * Deep learning fundamentals: optimization, architectures, embeddings, transfer learning, sequence modeling.
 * LLM application engineering: prompting, tool use, RAG, vector search, grounding, context management.
+* Workflow automation and orchestration: know when to use n8n, LangGraph, Airflow, or custom services for AI-enabled systems.
 * Evaluation: offline metrics, online metrics, human review, hallucination detection, regression testing.
 * MLOps and production ML: deployment, monitoring, data drift, experiment tracking, CI/CD, rollback strategy.
 * System design: latency, throughput, cost, reliability, observability, caching, batching, and failure modes.

--- a/docs/interview_questions_2026.md
+++ b/docs/interview_questions_2026.md
@@ -408,6 +408,19 @@ Monitoring:
 
 ---
 
+## Section 8: AI Workflow Automation
+
+**Q20: When would you use n8n in an AI system, and when would you avoid it?**
+
+**Strong Answer:**
+> Use **n8n** when the system is driven by operational workflows: webhooks, SaaS integrations, approvals, notifications, CRM updates, or internal back-office automation. It is especially strong when product and operations teams need visibility into the workflow.
+
+> Avoid using n8n as the only orchestration layer when the AI core needs complex state machines, agent loops, custom recovery logic, deep testing, or highly optimized retrieval and reasoning. In those cases, use n8n as the outer workflow shell and call a code-first backend such as a FastAPI or LangGraph service.
+
+> A good interview answer also mentions idempotency, approval gates, retries, audit logs, and policy checks before executing any AI-suggested action.
+
+---
+
 ## Quick Reference: Interview Pattern Cheatsheet
 
 | Topic | 30-second answer | Full answer depth |
@@ -418,4 +431,5 @@ Monitoring:
 | Hallucination | LLM generates false information confidently | Detection (NLI, LLM judge), mitigation (RAG, CoT, grounding prompts) |
 | Class imbalance | Class weights, resampling, threshold adjustment | Metrics: PR-AUC, F1; SMOTE, focal loss |
 | Agent vs LLM chain | Agents have loops, conditionals, tool use; chains are fixed | LangGraph vs LCEL vs direct API calls |
+| n8n vs LangGraph vs Airflow | n8n for operational automation, LangGraph for agent control, Airflow for scheduled data pipelines | Tradeoffs in state, approvals, integrations, retries, and ownership |
 | Embedding vs fine-tuning | Embedding: fast, cheap, good for similarity; FT: slow, expensive, changes model behavior | When each wins |

--- a/docs/resources-and-references.md
+++ b/docs/resources-and-references.md
@@ -20,6 +20,8 @@ These references are especially useful for 2025-2026 style interviews focused on
 5. [Full Stack Deep Learning](https://fullstackdeeplearning.com/)
 6. [Made With ML](https://madewithml.com/)
 7. [Chip Huyen blog](https://huyenchip.com/blog/)
+8. [n8n official site](https://n8n.io/)
+9. [n8n documentation](https://docs.n8n.io/)
 
 ## Additional Topics
 
@@ -57,3 +59,6 @@ Named Entity Recognition (NER) is an NLP task where a model identifies and class
 * tagging organizations and locations in news articles,
 * compliance and document review,
 * search enrichment and knowledge graph construction.
+
+#### What is workflow automation for AI systems?
+Workflow automation for AI systems is the operational layer that connects triggers, approvals, APIs, models, and downstream business systems into a repeatable execution path. In practice, teams often use tools like n8n for event-driven business automation, Airflow for scheduled data workflows, and code-first frameworks such as LangGraph when they need deeper stateful agent control.

--- a/docs/study-pattern.md
+++ b/docs/study-pattern.md
@@ -75,6 +75,7 @@ This guide provides a structured study plan for ML, AI Engineer, and Data Engine
 | Embedding Models | 🟡 | Dense vs sparse, embedding drift | [Vector DBs Guide](../ai_genai/intro_vector_databases.md) |
 | LLMOps | 🔴 | Tracing, evals, cost tracking, deployment | [LLMOps Guide](../ai_genai/intro_llmops.md) |
 | Agentic AI | 🔴 | ReAct, Plan-Execute, multi-agent systems | [Agentic AI Guide](../ai_genai/intro_agentic_ai.md) |
+| n8n / AI Workflow Automation | 🟡 | Webhooks, approval flows, AI-enabled business automation | [n8n Guide](../ai_genai/intro_n8n.md) |
 | MCP (Model Context Protocol) | 🔴 | Tool servers, client-server architecture | [MCP Guide](../ai_genai/intro_mcp.md) |
 | LangChain / LangGraph | 🟡 | LCEL, chains, agents, memory | [LangChain Guide](../ai_genai/intro_langchain.md) |
 | Anthropic / Claude API | 🟡 | Tool use, caching, extended thinking | [Anthropic Guide](../ai_genai/intro_anthropic.md) |

--- a/frameworks/README.md
+++ b/frameworks/README.md
@@ -29,6 +29,7 @@ A comprehensive reference for all major ML/AI frameworks, local LLM runners, fin
 | TensorFlow/Keras | Training Framework | Build and train neural networks | Production deployment, mobile |
 | JAX | Training Framework | High-performance ML research | Google infra, research labs |
 | [LangChain](./intro_langchain.md) | LLM Orchestration | Chain LLM calls, agents, RAG | LLM application development |
+| [n8n](../ai_genai/intro_n8n.md) | Workflow Automation | Connect apps, webhooks, approvals, and AI steps | Operational AI automation and business workflows |
 | LlamaIndex | RAG Framework | Document indexing and retrieval | Document Q&A, knowledge bases |
 | Haystack | NLP Pipeline | Search and NLP pipelines | Enterprise search, NLP products |
 | [Unsloth](./intro_unsloth.md) | Fine-tuning | Fast LoRA/QLoRA fine-tuning | Efficient custom model training |
@@ -103,6 +104,7 @@ For building LLM applications, RAG pipelines, and AI agents.
 | Framework | Description | Strengths | Weaknesses | Best For |
 |-----------|-------------|-----------|------------|----------|
 | **[LangChain](./intro_langchain.md)** | LLM application framework | Huge community, many integrations | Abstraction overhead, breaking changes | Rapid LLM app prototyping |
+| **[n8n](../ai_genai/intro_n8n.md)** | Visual workflow automation | Fast integrations, approvals, business workflow visibility | Less suited for deep agent state management | AI-enabled operations and internal tooling |
 | **LlamaIndex** | Data indexing + RAG | Best-in-class RAG, document handling | More limited for general agents | Document Q&A, knowledge bases |
 | **Haystack** | NLP pipeline framework | Enterprise-ready, production-focused | Smaller community | Enterprise search pipelines |
 | **DSPy** | LLM programming | Automatic prompt optimization | New, smaller community | Research, optimized pipelines |
@@ -154,7 +156,17 @@ In practice, many teams use LlamaIndex for the RAG layer and LangChain for agent
 
 ---
 
-**Q4: Compare PyTorch and TensorFlow for production ML.** 🟡 Intermediate
+**Q4: When would you choose n8n over LangChain or LangGraph?** 🟡 Intermediate
+
+Choose **n8n** when the problem is mostly workflow automation: webhooks, SaaS integrations, approvals, routing, and AI calls embedded inside business processes.
+
+Choose **LangChain** for general LLM application development and **LangGraph** when you need deeper control over state, loops, and agent execution.
+
+In many production systems, n8n handles the outer operational workflow while LangChain or LangGraph powers the reasoning-heavy backend.
+
+---
+
+**Q5: Compare PyTorch and TensorFlow for production ML.** 🟡 Intermediate
 
 **PyTorch** is dominant in research and has strong production tools (TorchServe, ONNX export, TorchScript). `torch.compile` in PyTorch 2.0 makes it competitive on performance.
 
@@ -164,7 +176,7 @@ For new projects in 2025: choose PyTorch — it has the largest research communi
 
 ---
 
-**Q5: What is the difference between Chroma and Pinecone for vector search?** 🟡 Intermediate
+**Q6: What is the difference between Chroma and Pinecone for vector search?** 🟡 Intermediate
 
 **Chroma** is an open-source, embedded vector database ideal for local development and prototyping. Zero infrastructure setup — runs in-process or as a local server.
 
@@ -174,7 +186,7 @@ For development/prototyping: Chroma. For production at scale: Pinecone, Qdrant (
 
 ---
 
-**Q6: What is Unsloth and how is it different from standard LoRA training?** 🟡 Intermediate
+**Q7: What is Unsloth and how is it different from standard LoRA training?** 🟡 Intermediate
 
 Unsloth is a Python library that provides optimized LoRA/QLoRA fine-tuning for LLMs. It achieves 2-5x speed improvements and 50-60% memory reduction compared to standard Hugging Face PEFT+Transformers training.
 
@@ -188,7 +200,7 @@ Standard LoRA uses the Hugging Face PEFT library which works well but is not opt
 
 ---
 
-**Q7: What is the difference between pgvector and dedicated vector databases?** 🔴 Advanced
+**Q8: What is the difference between pgvector and dedicated vector databases?** 🔴 Advanced
 
 **pgvector** adds vector similarity search to PostgreSQL using an extension. Strengths: no new infrastructure, SQL interface, ACID transactions, join with relational data, familiar tooling. Weaknesses: slower for large-scale (100M+ vectors), limited indexing options (IVFFlat, HNSW).
 
@@ -205,6 +217,7 @@ Choose pgvector if you already use PostgreSQL and have < 10M vectors. Choose a d
 - [Hugging Face Documentation](https://huggingface.co/docs)
 - [PyTorch Documentation](https://pytorch.org/docs/)
 - [LangChain Documentation](https://python.langchain.com/docs/)
+- [n8n Documentation](https://docs.n8n.io/)
 - [LlamaIndex Documentation](https://docs.llamaindex.ai/)
 - [Unsloth GitHub](https://github.com/unslothai/unsloth)
 - [Chroma Documentation](https://docs.trychroma.com/)

--- a/index.html
+++ b/index.html
@@ -659,7 +659,7 @@ const TRACKS = [
     id: 'ai_genai',
     icon: '🤖',
     title: 'AI & GenAI',
-    desc: 'RAG, vector databases, LLMOps, agentic AI, multi-agent systems, MCP, LangChain, LangGraph, LangSmith, CrewAI, and Anthropic Claude API.',
+    desc: 'RAG, vector databases, LLMOps, agentic AI, multi-agent systems, n8n, MCP, LangChain, LangGraph, LangSmith, CrewAI, and Anthropic Claude API.',
     color: '#d2a8ff',
     files: [
       { label: 'LLM Fundamentals', path: 'ai_genai/intro_llm_fundamentals.md' },
@@ -673,6 +673,8 @@ const TRACKS = [
       { label: 'Multi-Agent Systems', path: 'ai_genai/intro_multi_agent_systems.md' },
       { label: 'Multi-Model Orchestration', path: 'ai_genai/intro_multi_model_orchestration.md' },
       { label: 'Multimodal AI', path: 'ai_genai/intro_multimodal_ai.md' },
+      { label: 'n8n', path: 'ai_genai/intro_n8n.md' },
+      { label: 'n8n (Advanced)', path: 'ai_genai/intro_n8n_advanced.md' },
       { label: 'MCP Protocol', path: 'ai_genai/intro_mcp.md' },
       { label: 'LangChain', path: 'ai_genai/intro_langchain.md' },
       { label: 'LangGraph', path: 'ai_genai/intro_langgraph.md' },


### PR DESCRIPTION
## Summary

This PR adds a new `n8n` topic to the repository using the same markdown-driven structure already used for other interview topics.

The goal is to expand the repo's AI workflow orchestration coverage without removing or replacing any existing content. This change introduces both introductory and advanced `n8n` material, then links that topic from the main discovery and study surfaces across the repo.

## What was added

### New topic guides
Added two new markdown guides under the AI / GenAI track:

- `ai_genai/intro_n8n.md`
- `ai_genai/intro_n8n_advanced.md`

These cover:
- what n8n is,
- where it fits in AI/ML and agent workflows,
- comparisons with LangGraph and Airflow,
- production design considerations,
- human-in-the-loop approval patterns,
- interview questions and answers,
- advanced workflow and architecture patterns.

### Repo-wide references and navigation updates
Updated repo navigation and topic discovery so `n8n` appears alongside other existing topics.

Updated:
- `README.md`
- `index.html`
- `docs/2026-interview-roadmap.md`
- `docs/2026-additional-questions.md`
- `docs/interview_questions_2026.md`
- `docs/resources-and-references.md`
- `docs/study-pattern.md`

### Cross-topic references
Added `n8n` references in related topic pages so it is discoverable where users are already reading about orchestration, agents, and workflow automation.

Updated:
- `ai_genai/intro_agentic_ai.md`
- `ai_genai/intro_agent_tool_use.md`
- `data_engineering/intro_apache_airflow.md`
- `frameworks/README.md`

## Why this change

The repo already covers several modern orchestration and agent-related topics such as LangChain, LangGraph, CrewAI, MCP, Airflow, and LLMOps. `n8n` is a relevant addition because it is increasingly used in AI-enabled workflow automation, internal tooling, SaaS integrations, and approval-based business processes.

Adding it improves interview prep coverage for:
- AI Engineer roles,
- Applied AI roles,
- automation-heavy GenAI roles,
- workflow orchestration discussions,
- system design conversations around low-code vs code-first orchestration.

## Scope

This PR only adds and updates documentation.

It does **not**:
- remove any existing content,
- rename existing topics,
- change the repo structure outside of adding the new markdown pages and references,
- modify non-documentation code paths.

## Testing / validation

Validated by:
- confirming the new markdown files exist,
- checking that `n8n` references were added across the main repo index surfaces,
- updating the static `index.html` navigation so the new pages are visible in the GitHub Pages-style UI.

## Notes

This PR keeps the existing content model intact and extends it using the same topic style already present in the repo.
