### PR TITLE
Add Project Setup guides, fix site navigation, and expand agent/LLM content

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Please check out [CrackingMachineLearningInterview](https://shafaypro.github.io/
 * [Cloud ML Platforms](#cloud-ml-platforms)
 * [System Design Track](#system-design-track)
 * [Frameworks Track](#frameworks-track)
+* [Project Setup & Engineering Track](#project-setup--engineering-track)
 * [Suggested Learning Order](#suggested-learning-order)
 * [Highlighted Projects](#highlighted-projects)
 * [Preparation Resources and References](./docs/resources-and-references.md)
@@ -69,6 +70,7 @@ Feel free to share the repository link in your blog, study notes, or interview p
 * [`system_design/`](./system_design): ML system design patterns, RAG pipelines, agent architectures, batch vs real-time systems. **(Expanded)**
 * [`deep_learning/`](./deep_learning): deep learning fundamentals, transformers, and applied training pipelines. **(Expanded)**
 * [`coding_challenges/`](./coding_challenges): Python and SQL interview practice guides for coding screens and data problem solving. **(New)**
+* [`project_setup/`](./project_setup): how to set up a project on GitHub and structure real ML/AI/agent/data-engineering repositories. **(New)**
 * `README.md`: repository landing page plus the original classic ML interview question bank.
 
 ## Suggested Learning Order
@@ -83,6 +85,7 @@ Use this order if you want to move from theory to production-grade AI engineerin
 7. [System Design Track](#system-design-track)
 8. [Coding Challenges Track](#coding-challenges-track)
 9. [Cloud ML Platforms](#cloud-ml-platforms)
+10. [Project Setup & Engineering Track](#project-setup--engineering-track) — ship it the right way
 
 ## Highlighted Projects
 Use these to turn the repo into a portfolio, not just a reading list:
@@ -150,6 +153,8 @@ Core topics:
 * [Deep Learning Overview](./deep_learning/README.md)
 * [Applied Deep Learning Roadmap](./deep_learning/intro_applied_deep_learning.md) **(New)**
 * [Transformers](./deep_learning/intro_transformers.md)
+* [Computer Vision (CNNs, Detection, Segmentation, ViT)](./deep_learning/intro_computer_vision.md) **(New)**
+* [Fine-Tuning (LoRA, QLoRA, PEFT, RLHF/DPO)](./deep_learning/intro_fine_tuning.md) **(New)**
 
 ## DevOps Track
 Use this track for infrastructure, CI/CD, containers, orchestration, IaC, and AI system testing interviews.
@@ -184,6 +189,7 @@ Core topics:
 * [Data Quality & Validation](./mlops/intro_data_quality.md)
 * [LLM Evaluation (Evals, Benchmarks, Hallucination Detection, HITL)](./mlops/intro_llm_evaluation.md) **(New)**
 * [Evaluation & Guardrails](./mlops/intro_evaluation_guardrails.md) **(New)**
+* [A/B Testing for ML (Experiment Design, Stats, Online Metrics)](./mlops/intro_ab_testing.md) **(New)**
 
 ## Cloud ML Platforms
 Use this track for cloud-specific ML engineer and MLOps roles at companies using AWS, GCP, or Azure.
@@ -225,6 +231,14 @@ Core topics:
 * [Unsloth](./frameworks/intro_unsloth.md)
 * [FastAPI — Production AI Backend Engineering](./frameworks/intro_fastapi.md) **(New)**
 * [Pydantic — Data Validation for AI Systems](./frameworks/intro_pydantic.md) **(New)**
+
+## Project Setup & Engineering Track
+Use this track to learn the engineering hygiene every ML/AI Engineer is expected to have: shipping projects on GitHub and structuring real repositories.
+
+Core topics:
+* [Project Setup & Engineering Overview](./project_setup/README.md) **(New)**
+* [How to Set Up a Project on GitHub (Git, Branching, PRs, CI, Pages, Secrets)](./project_setup/intro_github_project_setup.md) **(New)**
+* [ML/AI Project Folder Structures (ML, DL, LLM, Agents, Data Eng)](./project_setup/intro_project_structure.md) **(New)**
 
 # Classic Question Bank
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Use these to turn the repo into a portfolio, not just a reading list:
 Use this track for AI Engineer, GenAI Engineer, LLM Engineer, Applied AI, and agent-platform interviews.
 
 Core topics:
+* [The Agentic AI Engineer Roadmap (34-topic curriculum: foundation → frontier)](./ai_genai/intro_agentic_ai_engineering_roadmap.md) **(New)**
 * [LLM & Generative AI Fundamentals](./ai_genai/intro_llm_fundamentals.md) **(New)**
 * [RAG](./ai_genai/intro_rag.md)
 * [RAG Engineering](./ai_genai/intro_rag_engineering.md) **(New)**
@@ -223,6 +224,7 @@ Core topics:
 Use this track for roles requiring hands-on Python API development and AI framework expertise.
 
 Core topics:
+* [Python for AI Engineering (async, type hints, Pydantic, APIs, logging)](./frameworks/intro_python_for_ai.md) **(New)**
 * [PyTorch](./frameworks/intro_pytorch.md)
 * [HuggingFace](./frameworks/intro_huggingface.md)
 * [LangChain](./frameworks/intro_langchain.md)

--- a/ai_genai/intro_agent_tool_use.md
+++ b/ai_genai/intro_agent_tool_use.md
@@ -146,6 +146,94 @@ planner-executor-agent/
 
 ---
 
+## Advanced Tool-Use Patterns
+
+Once the basic call → execute → feed-result loop works, these patterns make tool
+use cheaper, safer, and able to scale to large tool libraries.
+
+### The Agentic Loop (Manual vs Managed)
+
+The core loop: call the model with `tools` → if it returns a tool-use request,
+execute the tool and append the result as a `tool_result` → repeat until the model
+stops requesting tools.
+
+- **Manual loop** — you write the `while` loop. Use it when you need custom
+  logging, conditional execution, or **human-in-the-loop approval** before a tool runs.
+- **SDK tool runner** — the SDK drives the loop for you (define tools as typed
+  functions/schemas, it handles execution and feedback). Use it for the common case.
+
+Always **append the full assistant response** (including tool-use blocks) before
+the tool results, and make sure each `tool_result` carries the matching
+`tool_use_id`. Set a **max-iterations cap** so a misbehaving agent can't loop forever.
+
+### Parallel Tool Calls
+
+A single model turn can request **multiple** tool calls. Execute independent ones
+concurrently and return **all** results in **one** user message. Splitting results
+across messages silently teaches the model to stop calling tools in parallel. For
+a tool that failed, still return a result with an error flag — don't drop it.
+
+### Strict Schemas & Validation
+
+Use strict JSON schemas (`additionalProperties: false`, explicit `required`) so the
+model's arguments validate exactly. Always validate inputs *inside* your handler
+before acting — the arguments are model output, not trusted input. Parse tool
+inputs with a real JSON parser; never string-match the serialized arguments.
+
+### Programmatic Tool Calling (PTC)
+
+Instead of one round-trip per tool call, let the model write a **script** that calls
+tools as functions inside a code-execution sandbox. Intermediate results stay in
+the running code (not the context window); only the final output returns to the
+model. Use it when chaining many sequential calls or when intermediate results are
+large and should be filtered before reaching the context.
+
+### Tool Search (scaling to many tools)
+
+With dozens or hundreds of tools, putting every schema in context is wasteful and
+hurts selection accuracy. **Tool search** lets the model discover and load only the
+relevant tool schemas on demand — and because schemas are *appended* rather than
+swapped, the prompt cache is preserved.
+
+### MCP — a Standard Tool Interface
+
+The **Model Context Protocol** lets agents connect to standardized tool servers
+(GitHub, databases, SaaS apps) without bespoke integrations per tool. Declare the
+server; the agent gains its tools. See [MCP](./intro_mcp.md).
+
+### Server-Side / Built-in Tools
+
+Providers offer hosted tools that run on their infrastructure — **web search**,
+**web fetch**, and **code execution** — declared in the `tools` list with no
+client-side execution loop. Great for grounding answers in current information or
+running computation without managing a sandbox yourself.
+
+### Security Checklist for Tool Use
+
+| Risk | Mitigation |
+|------|-----------|
+| Destructive/irreversible action | Human-in-the-loop approval; reversibility check |
+| Malicious tool arguments | Strict schema + handler-side validation; allowlist commands for a bash tool |
+| Path traversal (file tools) | Resolve to a canonical path; confine to a project root; reject `..`/symlinks |
+| Prompt injection via tool output | Treat returned content as untrusted data, not instructions |
+| Secret leakage | Keep credentials host-side; never put API keys in prompts or tool args |
+| Runaway cost/loops | Max-iteration and token budgets |
+
+### Interview Questions
+
+1. **Why must parallel tool results go in one message?** → Splitting them trains
+   the model to stop issuing parallel calls and breaks `tool_use_id` pairing.
+2. **What does programmatic tool calling save?** → Round-trips and tokens — only
+   the final result re-enters the context, not every intermediate value.
+3. **How do you scale an agent to hundreds of tools?** → Tool search / dynamic
+   discovery so only relevant schemas load, preserving the prompt cache.
+4. **How do you make a `bash`/file tool safe?** → Sandboxing, command allowlists,
+   canonical-path confinement, timeouts, and logging every call.
+5. **What is MCP and why does it matter?** → A standard protocol for exposing tools
+   to agents, so tool servers are reusable across agents instead of bespoke.
+
+---
+
 ## Related Topics
 
 - [Multi-Agent Systems](./intro_multi_agent_systems.md)

--- a/ai_genai/intro_agentic_ai.md
+++ b/ai_genai/intro_agentic_ai.md
@@ -585,6 +585,141 @@ Research the current state of vector databases in 2026:
 
 ---
 
+## Production Agent Engineering
+
+Building a demo agent is easy; making one reliable, cheap, and debuggable in
+production is the actual job. This section covers the decisions interviewers
+probe most.
+
+### Should You Even Build an Agent?
+
+Before reaching for an agent, check four criteria. If any answer is "no," use a
+simpler tier — a single LLM call or a code-orchestrated **workflow**.
+
+| Criterion | Question |
+|-----------|----------|
+| **Complexity** | Is the task multi-step and hard to fully specify up front? |
+| **Value** | Does the outcome justify higher cost and latency? |
+| **Viability** | Is the model actually capable at this task type? |
+| **Cost of error** | Can mistakes be caught and recovered (tests, review, rollback)? |
+
+> **Rule of thumb:** Single call → classification/extraction/Q&A. Workflow →
+> multi-step pipeline with logic *you* control. Agent → open-ended task where the
+> model must decide its own trajectory.
+
+### Designing the Tool Surface
+
+The shape of your tools determines what your harness can do. A **bash tool** gives
+the model maximum leverage but hands the harness only an opaque command string. A
+**dedicated tool** (`send_email`, `edit_file`) gives the harness a typed, named
+hook it can gate, validate, render, or run in parallel.
+
+**Promote an action from bash to a dedicated tool when you need to:**
+- **Gate it** — hard-to-reverse actions (sending messages, deleting data, external
+  API writes) should be confirmable. `send_email` is easy to gate; `bash -c "curl -X POST..."` is not.
+- **Enforce invariants** — a dedicated `edit` tool can reject a write if the file
+  changed since the model last read it.
+- **Render it** — some actions deserve custom UI (an approval modal, a diff view).
+- **Parallelize it** — mark read-only tools (`grep`, `glob`) parallel-safe; the
+  harness can't tell a safe `grep` from an unsafe `git push` inside bash.
+
+**Tool definition best practices:** clear names, descriptions that say *when* to
+call the tool (not just what it does), `enum` for fixed-value params, and only
+truly-required fields in `required`. On recent models that call tools more
+conservatively, an explicit "Call this when…" trigger in the description measurably
+raises the should-call rate.
+
+### Context Management for Long-Running Agents
+
+Agents accumulate context across many turns and will blow the context window if
+unmanaged. Three complementary strategies:
+
+| Strategy | What it does | Use when |
+|----------|--------------|----------|
+| **Context editing** | Prunes stale tool results / thinking blocks | Old tool outputs are no longer relevant |
+| **Compaction** | Summarizes earlier history into a compact block | Conversation approaches the window limit |
+| **Memory** | Persists state to files/DB across sessions | State must survive process restarts |
+
+Many long-horizon agents use all three. Compaction summarizes *within* a session;
+memory persists *across* sessions.
+
+**Prompt caching for agents** — caching is a prefix match, so:
+- Keep the system prompt and tool list **frozen** (don't interpolate timestamps,
+  don't reorder tools) — any change at the front invalidates everything after it.
+- To change behavior mid-run, append an instruction as a message rather than
+  editing the system prompt.
+- To use a cheaper model for a sub-task, spawn a **subagent** instead of swapping
+  the model mid-conversation (a model switch invalidates the cache).
+
+### Managed vs. Self-Hosted Agents
+
+| | **Self-hosted loop** (your code runs the loop) | **Managed agents** (provider runs the loop) |
+|---|---|---|
+| Control | Maximum — custom logging, approval gates | Provider orchestrates; you stream events |
+| Tool execution | Your infrastructure | Provider-hosted container (or your own) |
+| State | You manage | Persisted, versioned agent configs + sessions |
+| Best for | Custom runtimes, on-prem, fine-grained control | Stateful agents, file mounts, fast time-to-prod |
+
+Anthropic's **Managed Agents** is one example of the managed pattern: you create a
+persisted, versioned Agent config (model, system prompt, tools), then start
+Sessions that reference it; the provider runs the loop and hosts a per-session
+container where tools execute.
+
+### Evaluating Agents
+
+Don't evaluate agents only on final-answer quality — evaluate the **trajectory**:
+
+- **Task success rate** — did it achieve the goal? (the headline metric)
+- **Trajectory quality** — were the tool calls sensible, or did it flail?
+- **Efficiency** — number of steps, tokens, and tool calls per task.
+- **Failure analysis** — categorize *why* tasks fail (wrong tool, bad parse, loop).
+
+Maintain a **task suite** the agent must pass on every change, and use
+LLM-as-judge for graded rubrics. See [LLM Evaluation](../mlops/intro_llm_evaluation.md).
+
+### Cost & Latency Optimization
+
+| Lever | Effect |
+|-------|--------|
+| **Right-size the model** | Use a smaller model (e.g. Haiku-tier) for routing/subagents, a larger one (Opus-tier) for hard reasoning |
+| **Prompt caching** | Cache the stable system prompt + tools (~10× cheaper on cache reads) |
+| **Effort/thinking controls** | Lower the reasoning effort for routine steps; raise it for hard ones |
+| **Parallel tool calls** | Execute independent tools concurrently, return all results in one turn |
+| **Cap the loop** | Set a max-steps / token budget so a runaway agent fails gracefully |
+| **Batch offline work** | Use batch APIs (≈50% cheaper) for non-latency-sensitive jobs |
+
+### Failure Modes & Guardrails
+
+| Failure mode | Mitigation |
+|--------------|-----------|
+| Infinite / repetitive loops | Max-step cap; detect repeated states |
+| Hallucinated tool arguments | Strict schemas (`additionalProperties: false`), validate before executing |
+| Destructive actions | Human-in-the-loop approval for irreversible tools |
+| Prompt injection via tool output | Treat tool/retrieved content as untrusted; don't let it override system instructions |
+| Silent quality drift | Continuous evals + tracing on every tool call |
+| Cost blowout | Token/step budgets; alerting on per-task spend |
+
+### Interview Questions
+
+1. **When should you NOT build an agent?** → When the task is single-step or fully
+   specifiable — a single call or a code-orchestrated workflow is cheaper, faster,
+   and more reliable.
+2. **Bash tool vs dedicated tools — trade-offs?** → Bash = max capability, opaque
+   to the harness; dedicated tools = gateable, validatable, parallelizable, but
+   you must build each one. Promote to dedicated when you need to gate/render/parallelize.
+3. **How do you keep a long-running agent within the context window?** → Context
+   editing (prune), compaction (summarize), and memory (persist across sessions).
+4. **How do you evaluate an agent?** → Task success rate + trajectory quality +
+   efficiency, on a fixed task suite, often with LLM-as-judge.
+5. **How do you defend against prompt injection in an agentic RAG system?** →
+   Treat retrieved/tool content as untrusted data, never as instructions; separate
+   the system/operator channel; validate and sandbox tool execution.
+6. **How do you cut agent cost without hurting quality?** → Right-size models per
+   sub-task, prompt-cache the stable prefix, lower effort on routine steps,
+   parallelize tool calls, and batch offline work.
+
+---
+
 ## Related Topics
 
 | Topic | Why It's Related |

--- a/ai_genai/intro_agentic_ai_engineering_roadmap.md
+++ b/ai_genai/intro_agentic_ai_engineering_roadmap.md
@@ -2,14 +2,18 @@
 
 A complete, layered curriculum for becoming a production-grade **Agentic AI
 Engineer** — from Python foundations to frontier topics like agent platforms and
-self-improving agents. Each topic gives you the concept, why it matters, the key
-things to know, and a **→ Deep dive** link to the in-repo guide that covers it in
-full.
+self-improving agents.
 
-> **How to use this:** Work top-to-bottom. The layers are ordered by dependency —
-> you genuinely need the Foundation layer before the Core Agentic layer, and so on.
+This is an **interview-prep** guide, so every topic follows the same shape:
+
+- **What it is** — a plain-English explanation of the concept and how it works.
+- **Key points** — the things you must be able to recall.
+- **Interview questions** — the questions you'll actually be asked, with concise answers.
+- **→ Deep dive** — links to the in-repo guide that covers it in full.
+
+> **How to use this:** Work top-to-bottom — the layers are ordered by dependency.
 > The final section, [What Actually Gets You Hired](#what-actually-gets-you-hired),
-> is what senior interviews really probe.
+> is the judgment senior interviews really probe.
 
 ---
 
@@ -69,56 +73,97 @@ full.
 
 ## 1. Python for AI Engineering
 
-The non-negotiable base. You need this before everything else.
+**What it is.** The everyday Python that LLM apps and agents are built from:
+concurrency for parallel API calls, type hints and Pydantic for schemas/validation,
+clean dependency/secret management, and robust error handling + logging. It's listed
+first because weak Python here surfaces immediately as flaky, slow, unobservable agents.
 
-- **Core Python** — data structures, comprehensions, generators, context managers, decorators.
-- **`async`/`await`** — concurrent API calls (agents make *many*); `asyncio.gather` to parallelize tool calls and model requests.
-- **Type hints** — `list[str]`, `dict[str, Any]`, `Optional`, `Literal`, generics; they make agent code maintainable and power schema generation.
-- **Pydantic models** — typed, validated data; the backbone of structured outputs and tool schemas.
-- **Environment management** — `venv`/`uv`/`poetry`, `.env` files, never hardcoding keys.
-- **Working with APIs** — `requests`/`httpx`, retries, timeouts, pagination, streaming.
-- **Error handling & logging** — typed exceptions, retry/backoff, structured logging with correlation IDs (essential for debugging non-deterministic agents).
+**Key points:**
+- Core Python: comprehensions, generators, context managers, decorators.
+- `async`/`await` for concurrent I/O (`asyncio.gather`, semaphores for rate limits).
+- Type hints (`list[str]`, `Literal`, `Optional`) and **Pydantic** for typed/validated data.
+- `venv`/`uv`, `.env` files, never hardcoding keys.
+- Retries with backoff, typed exceptions, structured logging with correlation IDs.
+
+**Interview questions:**
+1. **When do you reach for `async` in an AI app?** → For I/O-bound concurrency —
+   parallel model/tool/DB calls. Use `asyncio.gather`, cap with a semaphore for rate
+   limits. Not for CPU-bound work (use processes).
+2. **Why Pydantic in an LLM pipeline?** → It validates/coerces data at the boundary,
+   auto-generates JSON schemas for tools, and loads typed config — so the rest of the
+   code can trust its types.
+3. **How do you handle a 429 vs a 400?** → Retry 429 (and 5xx) with exponential
+   backoff + jitter; never retry 400 — it's a client error, fix the request.
 
 → **Deep dive:** [Python for AI Engineering](../frameworks/intro_python_for_ai.md) ·
 [Pydantic](../frameworks/intro_pydantic.md) · [FastAPI](../frameworks/intro_fastapi.md)
 
 ## 2. LLM Fundamentals
 
-How the thing you're orchestrating actually behaves.
+**What it is.** How the model you're orchestrating actually behaves. A modern LLM is a
+**decoder-only transformer** that predicts the next token autoregressively; *self-attention*
+lets each token weigh every other token in the context. Everything you do — prompting,
+tools, RAG — is shaping that next-token prediction.
 
-- **Transformers (conceptual)** — self-attention lets every token attend to every other; decoder-only models predict the next token autoregressively.
-- **Tokens & context windows** — text → tokens (~4 chars each); the window caps input+output. Budget it.
-- **Sampling** — `temperature` (randomness) and `top_p` (nucleus) trade determinism for creativity; low for extraction/code, higher for ideation.
-- **System vs user prompts** — system sets persona/rules/constraints (higher authority); user carries the task.
-- **Few-shot prompting** — examples in the prompt steer format and behavior without fine-tuning.
-- **Prompt injection (basics)** — untrusted text can hijack instructions; never trust retrieved/tool content as commands.
+**Key points:**
+- **Tokens & context window** — text → tokens (~4 chars each); the window caps input+output.
+- **Sampling** — `temperature` (randomness) and `top_p` (nucleus) trade determinism for creativity.
+- **System vs user prompts** — system sets persona/rules (higher authority); user carries the task.
+- **Few-shot prompting** — in-context examples steer format/behavior without fine-tuning.
+- **Prompt injection (basics)** — untrusted text can hijack instructions.
+
+**Interview questions:**
+1. **Explain self-attention in one sentence.** → A mechanism that lets each token
+   compute a weighted combination of all other tokens' representations, so context flows
+   between positions.
+2. **What is a context window and why does it matter?** → The max tokens a model can
+   attend to per request; exceed it and you must truncate, summarize, or retrieve.
+3. **`temperature` vs `top_p`?** → Both control randomness; temperature scales the whole
+   distribution, top_p truncates it to the smallest set covering probability `p`. Tune one.
+4. **Why do LLMs hallucinate?** → They predict plausible tokens, not verified facts;
+   with no grounding they'll confidently fill gaps. Mitigate with RAG, citations, lower temperature.
 
 → **Deep dive:** [LLM Fundamentals](./intro_llm_fundamentals.md) · [Transformers](../deep_learning/intro_transformers.md)
 
 ## 3. Prompt Engineering
 
-The cheapest, fastest lever on agent quality.
+**What it is.** The practice of structuring instructions, context, and examples to get
+reliable behavior out of an LLM — the cheapest, fastest lever on quality before you
+reach for tools or fine-tuning.
 
-- **Chain-of-Thought (CoT)** — "think step by step" for multi-step reasoning.
+**Key points:**
+- **Chain-of-Thought (CoT)** — ask the model to reason step by step on multi-step problems.
 - **Zero-shot vs few-shot** — no examples vs a handful of worked examples.
-- **Structured-output prompting** — ask for JSON/XML; pair with schema enforcement.
-- **Role prompting** — assign an expert persona to shape tone and rigor.
-- **ReAct (Reason + Act)** — interleave reasoning traces with tool actions — the canonical agent prompting pattern.
-- **XML/JSON coercion** — wrap fields in tags/keys the model reliably emits; parse defensively.
-- **Hallucination control** — ground with retrieval, demand citations, lower temperature, allow "I don't know."
+- **Role prompting** — assign an expert persona to shape tone/rigor.
+- **ReAct (Reason + Act)** — interleave reasoning with tool actions; the canonical agent pattern.
+- **Structured-output / XML-JSON coercion** — ask for tagged/keyed fields; parse defensively.
+- **Hallucination control** — ground with retrieval, demand citations, allow "I don't know."
+
+**Interview questions:**
+1. **What is Chain-of-Thought and when does it help?** → Prompting the model to show
+   intermediate reasoning; it improves multi-step math/logic/planning tasks.
+2. **Zero-shot vs few-shot — trade-off?** → Few-shot improves format adherence and
+   tricky behavior but costs tokens and can bias toward the examples; zero-shot is cheaper.
+3. **What is the ReAct pattern?** → Reason → Act (call a tool) → Observe (result) →
+   repeat; it lets the model use tools and ground its reasoning in real results.
+4. **How do you make a model return strict JSON?** → Schema-constrained/structured
+   outputs or strict tool mode, plus a retry that feeds the validation error back.
 
 → **Deep dive:** [Prompt Engineering](./intro_prompt_engineering.md)
 
 ## 4. LLM APIs
 
-OpenAI, Anthropic, and Google — calling them well.
+**What it is.** The provider interfaces (OpenAI, Anthropic, Google) you call to run a
+model: you send messages + parameters to a chat/messages endpoint and get content blocks
+back, optionally streamed. Knowing their tiers, limits, and failure modes is core to
+building cost-effective, reliable systems.
 
-- **Calling them** — all expose a chat/messages endpoint; you send messages + params and get content blocks back.
-- **Streaming** — Server-Sent Events deliver tokens incrementally; essential for UX and to avoid request timeouts on long outputs.
-- **Rate limits** — RPM/TPM caps; handle `429` with exponential backoff (SDKs retry automatically).
-- **Token counting** — use the **provider's own** counter (not `tiktoken` for Claude — it undercounts).
-- **Error handling** — typed exceptions; retry 429/5xx, don't retry 4xx.
-- **Model tiers (cost vs capability)** — frontier (hardest reasoning), balanced workhorse, fast/cheap. Route by task.
+**Key points:**
+- **Streaming** — Server-Sent Events deliver tokens incrementally (better UX, avoids timeouts).
+- **Rate limits** — RPM/TPM caps; handle `429` with backoff (SDKs auto-retry).
+- **Token counting** — use the **provider's** counter (`tiktoken` undercounts Claude).
+- **Errors** — retry 429/5xx, don't retry 4xx.
+- **Model tiers** — frontier (hardest reasoning) → balanced workhorse → fast/cheap; route by task.
 
 | Provider | Frontier / reasoning | Balanced | Fast / cheap |
 |----------|----------------------|----------|--------------|
@@ -126,7 +171,15 @@ OpenAI, Anthropic, and Google — calling them well.
 | OpenAI | GPT frontier tier | GPT mid tier | GPT mini/nano tier |
 | Google | Gemini Pro/Ultra tier | Gemini Flash | Gemini Flash-Lite |
 
-> Always confirm current model IDs and pricing from each provider's docs — they change frequently.
+> Confirm current model IDs and pricing from each provider's docs — they change often.
+
+**Interview questions:**
+1. **Why stream responses?** → Lower perceived latency (tokens appear immediately) and
+   it avoids HTTP timeouts on long outputs.
+2. **How do you choose between model tiers?** → Pick the cheapest tier that clears the
+   quality bar on an eval set; route easy traffic to a small model, escalate hard cases.
+3. **How do you handle rate limits gracefully?** → Exponential backoff + jitter on 429,
+   respect `retry-after`, cap concurrency with a semaphore, and consider batching.
 
 → **Deep dive:** [Anthropic & Claude API](./intro_anthropic.md) · [Multi-Model Orchestration](./intro_multi_model_orchestration.md)
 
@@ -136,30 +189,60 @@ OpenAI, Anthropic, and Google — calling them well.
 
 ## 5. Tool Use / Function Calling
 
-The heartbeat of agentic systems.
+**What it is.** The mechanism that lets an LLM *do* things, not just talk. You give the
+model tool definitions (name, description, JSON schema). When it wants to act, it returns
+a **tool-use request** with arguments; your code executes the tool and feeds the **result**
+back into the conversation. This loop is the heartbeat of every agent.
 
-- **How it works** — you pass tool definitions (name, description, JSON schema); the model returns a *tool-use request* with arguments; you execute it and feed the **tool result** back into context; repeat.
-- **JSON schemas** — `type: object`, typed properties, `required`, `enum`; use strict mode (`additionalProperties: false`) for guaranteed-valid args.
-- **Parsing responses** — read tool-use blocks, match each by `tool_use_id`.
-- **Multi-tool calls in one turn** — execute independent calls in parallel; return **all** results in **one** message.
-- **Result injection** — append the assistant turn (with tool-use blocks) *then* the tool results, so the model can continue.
+**Key points:**
+- Tool definition = name + description + JSON input schema; strict mode (`additionalProperties: false`) guarantees valid args.
+- The model **requests**; *you* execute — the model never runs code itself.
+- Parse tool-use blocks; match each by `tool_use_id`.
+- Multiple tools in one turn → execute in parallel, return **all** results in **one** message.
+- Append the assistant turn (with tool-use blocks) *then* the tool results.
+
+**Interview questions:**
+1. **Walk me through one function-calling turn.** → Send tools + messages → model
+   returns a tool-use block with args → execute the tool → append assistant turn + a
+   `tool_result` (matching `tool_use_id`) → call again → model produces the final answer.
+2. **Why must parallel tool results go in one message?** → Splitting them breaks the
+   `tool_use_id` pairing and trains the model to stop issuing parallel calls.
+3. **Does the LLM execute the tool?** → No — it only emits a structured request; your
+   harness runs the code and returns the result. (Server-side tools are the exception:
+   the provider runs them.)
 
 → **Deep dive:** [Agent Systems & Tool Use](./intro_agent_tool_use.md)
 
 ## 6. Agent Loops
 
-The engine: **observe → think → act → observe**.
+**What it is.** The control loop that turns a one-shot LLM into an agent:
+**observe → think → act → observe**. The model reasons, calls a tool, sees the result,
+and repeats until the goal is met or a stop condition fires. The simplest concrete form is
+the ReAct loop.
 
-- **Minimal ReAct loop** — call model → if it requests a tool, run it, append result, loop; else stop.
+**Key points:**
+- Minimal loop: call model → if it requests a tool, run it, append result, loop; else stop.
 - **Stopping conditions** — `end_turn`, goal reached, or a max-iteration / token budget.
-- **Handling stalls** — detect repeated states/loops; add a "if stuck, ask for help or stop" instruction; cap retries.
-- **Manual vs SDK-driven** — write the loop yourself for approval gates and custom logging; use an SDK tool runner for the common case.
+- **Stall handling** — detect repeated states; instruct "if stuck, ask or stop"; cap retries.
+- **Manual vs SDK runner** — write the loop yourself for approval gates/logging; use a runner for the common case.
+
+**Interview questions:**
+1. **Describe the basic agent loop.** → Observe (context/result) → think (model reasons)
+   → act (tool call) → observe (tool result), repeating until a stop condition.
+2. **How do you stop an agent from looping forever?** → Max-iteration and token budgets,
+   loop/repeat-state detection, and explicit stop instructions.
+3. **When would you write the loop manually instead of using a framework runner?** →
+   When you need human-in-the-loop approval, custom logging/tracing, or conditional
+   execution the runner doesn't expose.
 
 → **Deep dive:** [Agentic AI](./intro_agentic_ai.md) (§ Agent Patterns, § Production Agent Engineering)
 
 ## 7. Memory Systems
 
-What the agent remembers, and where.
+**What it is.** How an agent stores and recalls information across a turn, a session, and
+multiple sessions. "Memory" isn't one thing — it spans the live context window, conversation
+history, retrievable facts, and persistent stores. Choosing the right kind for each need is
+what keeps agents both capable and affordable.
 
 | Memory type | What it holds | Backed by |
 |-------------|---------------|-----------|
@@ -169,28 +252,53 @@ What the agent remembers, and where.
 | **Procedural** | How-to / skills | Tools, prompts, skill files |
 | **External / long-term** | Anything beyond the window | Vector DB, SQL, files |
 
-- **When to use each** — keep hot context in-window; offload facts to a vector store; persist run history for resumption; encode procedures as tools/skills.
-- **Trade-offs** — more in-context memory = higher cost/latency; retrieve selectively.
+**Key points:**
+- Keep hot context in-window; offload facts to a vector store; persist history for resumption.
+- More in-context memory = higher cost/latency → retrieve selectively.
+
+**Interview questions:**
+1. **What are the types of agent memory?** → Working (in-context), episodic (history),
+   semantic (facts via vector store), procedural (skills/tools), and external/long-term.
+2. **When do you use a vector store vs the context window for memory?** → Window for the
+   small, hot working set; vector store for a large knowledge base retrieved on demand.
+3. **How do you give an agent memory across sessions?** → Persist state/history/facts to
+   an external store (DB/vector DB/files) and rehydrate on the next session.
 
 → **Deep dive:** [Agentic AI § Agent Memory](./intro_agentic_ai.md) · [Vector Databases](./intro_vector_databases.md)
 
 ## 8. RAG (Retrieval-Augmented Generation)
 
-Ground answers in your data instead of model memory.
+**What it is.** A pattern that grounds the model in *your* data: you retrieve relevant
+chunks from a knowledge base (usually via vector similarity) and put them in the prompt,
+so the model answers from real sources instead of parametric memory. It's the standard
+fix for hallucination and stale knowledge.
 
-- **Chunking** — size + overlap; semantic/recursive splitting beats fixed windows; respect document structure.
-- **Embedding models** — turn text into vectors; pick by domain, dimension, cost.
-- **Vector databases** — Pinecone, Weaviate, Chroma, pgvector, FAISS.
-- **Similarity search** — cosine/dot-product top-k retrieval.
-- **Hybrid search** — combine BM25 (lexical) + dense (semantic) for recall on rare terms.
-- **Reranking** — a cross-encoder reorders candidates for precision before they hit the prompt.
-- **Context stuffing vs retrieval** — stuff when the corpus is tiny; retrieve when it's large.
+**Key points:**
+- **Chunking** — size + overlap; semantic/recursive splitting beats fixed windows.
+- **Embeddings** — turn text into vectors; pick by domain/dimension/cost.
+- **Vector DBs** — Pinecone, Weaviate, Chroma, pgvector, FAISS.
+- **Hybrid search** — BM25 (lexical) + dense (semantic) for recall on rare terms.
+- **Reranking** — a cross-encoder reorders candidates for precision.
+- **Stuffing vs retrieval** — stuff a tiny corpus; retrieve from a large one.
+
+**Interview questions:**
+1. **Explain the RAG pipeline end to end.** → Ingest → chunk → embed → store; at query
+   time embed the query → similarity search → (rerank) → stuff top-k into the prompt → generate.
+2. **Why hybrid search?** → Dense search misses exact/rare terms (IDs, codes); BM25
+   catches them. Combining both improves recall.
+3. **What does a reranker add?** → It reorders retrieved candidates with a more accurate
+   cross-encoder so the most relevant chunks reach the limited context — improving precision.
+4. **How does RAG reduce hallucination?** → It supplies grounded source text and you
+   instruct the model to answer only from it, with citations.
 
 → **Deep dive:** [RAG](./intro_rag.md) · [RAG Engineering](./intro_rag_engineering.md) · [Vector Databases — Advanced](./intro_vector_databases_advanced.md)
 
 ## 9. Frameworks: LangChain / LlamaIndex / CrewAI / AutoGen
 
-Deeply understand **at least one** — and know its limits.
+**What it is.** Libraries that provide ready-made abstractions for LLM apps and agents —
+chains, tools, memory, retrievers, and orchestration — so you don't rebuild the loop each
+time. The senior skill is knowing what they give you, what they hide, and when raw SDK code
+is the better choice.
 
 | Framework | Sweet spot |
 |-----------|-----------|
@@ -199,9 +307,20 @@ Deeply understand **at least one** — and know its limits.
 | **CrewAI** | Role-based multi-agent "crews" |
 | **AutoGen** | Conversational multi-agent (Microsoft) |
 
-- **What they provide** — prompt/chain abstractions, tool integrations, memory, retrievers, orchestration.
-- **What they hide** — the raw API loop, exact prompts, token usage; debugging through layers is harder.
-- **When they help vs hurt** — great for fast prototypes and standard patterns; raw SDK often wins for fine-grained control, performance, and cost transparency. Senior engineers can articulate this trade-off.
+**Key points:**
+- They **provide** prompt/chain abstractions, integrations, memory, retrievers, orchestration.
+- They **hide** the raw API loop, exact prompts, and token usage — harder to debug/optimize.
+- Great for prototypes and standard patterns; raw SDK often wins for control, performance, cost transparency.
+
+**Interview questions:**
+1. **When would you NOT use a framework?** → When you need fine-grained control over the
+   loop/prompts, maximum performance, predictable cost, or simple logic a framework
+   over-abstracts — raw SDK is clearer.
+2. **What do these frameworks abstract away, and why is that a risk?** → The agent loop,
+   prompt construction, and token accounting — which makes debugging and cost control harder
+   when something goes wrong inside the abstraction.
+3. **LangChain vs LlamaIndex?** → LangChain is a general orchestration toolkit; LlamaIndex
+   is data/RAG-centric (indexing, retrieval). They overlap and are often combined.
 
 → **Deep dive:** [LangChain](./intro_langchain.md) · [LangGraph](./intro_langgraph.md) · [CrewAI](./intro_crewai.md) · [LangChain LCEL/Advanced](../frameworks/intro_langchain.md)
 
@@ -211,69 +330,136 @@ Deeply understand **at least one** — and know its limits.
 
 ## 10. Multi-Agent Systems
 
-Multiple specialized agents beat one generalist.
+**What it is.** Architectures where several specialized agents collaborate instead of one
+generalist doing everything. A coordinator/orchestrator decomposes the goal and delegates
+to worker agents (researcher, coder, reviewer), each with its own focused prompt and tools.
+Specialization typically beats a single overloaded agent on reliability.
 
-- **Orchestrator–worker** — a coordinator delegates subtasks to specialized workers.
-- **Supervisor pattern** — a supervisor routes, monitors, and aggregates.
-- **Delegation & shared state** — pass context explicitly; agents don't share memory unless you wire it.
-- **Communication protocols** — message passing, structured handoffs, blackboard.
-- **Why specialize** — focused prompts/tools per role → higher reliability than one overloaded agent.
+**Key points:**
+- **Orchestrator–worker** and **supervisor** patterns route, delegate, monitor, aggregate.
+- Agents don't share memory unless you wire it — pass context explicitly in handoffs.
+- Communication via message passing / structured handoffs / a shared blackboard.
+
+**Interview questions:**
+1. **Why use multiple agents instead of one?** → Focused prompts/tools per role give
+   higher reliability and easier debugging than one agent juggling everything.
+2. **What is the orchestrator–worker pattern?** → A coordinator breaks the task into
+   subtasks and delegates each to a specialized worker, then aggregates the results.
+3. **How do agents share state?** → Not automatically — via explicit message passing, a
+   shared store/blackboard, or by writing to a common workspace.
 
 → **Deep dive:** [Multi-Agent Systems](./intro_multi_agent_systems.md)
 
 ## 11. MCP (Model Context Protocol)
 
-Anthropic's open standard for agent↔tool communication.
+**What it is.** An open standard (from Anthropic) for how agents talk to tools and data
+sources. Instead of bespoke per-tool integrations, you run an **MCP server** that exposes
+tools/resources/prompts over a common protocol; any MCP-aware agent can discover and use
+them — like "USB-C for AI tools."
 
-- **MCP servers** — expose tools/resources/prompts over a standard protocol.
-- **Building tools** — implement a server once; any MCP-aware agent can use it.
-- **Connecting agents** — declare the server; the agent gains its tools without bespoke integration.
-- **Tool discovery** — clients enumerate a server's capabilities at runtime.
+**Key points:**
+- MCP servers expose tools/resources/prompts; clients (agents) connect and discover them.
+- Build a tool server once → reusable across agents and vendors.
+- Solves the N×M integration problem as the tool ecosystem grows.
+
+**Interview questions:**
+1. **What problem does MCP solve?** → It standardizes agent↔tool communication so tools
+   are built once and reused, instead of N bespoke integrations per agent.
+2. **What does an MCP server expose?** → Tools (actions), resources (data/context), and
+   prompts, all discoverable by clients at runtime.
+3. **MCP vs a plain function-calling tool?** → Function calling is in-process per app; MCP
+   is a transport/standard so the same tool server works across many agents/clients.
 
 → **Deep dive:** [MCP](./intro_mcp.md) · [Agent Communication Standards](#32-agent-communication-standards)
 
 ## 12. Planning & Task Decomposition
 
-Break a goal into executable steps.
+**What it is.** Getting an agent to break a complex goal into an ordered set of executable
+subtasks before (or while) acting. Plan-and-execute generates a plan up front; reactive
+agents (ReAct) plan step by step. Good planning includes **replanning** when a step fails.
 
-- **Plan-and-execute** — generate a plan, then execute steps (vs reactive ReAct).
+**Key points:**
+- **Plan-and-execute** vs reactive (ReAct) planning.
 - **Hierarchical planning** — high-level plan → sub-plans → actions.
-- **Replanning** — when a step fails, revise the plan rather than crashing.
+- **Replanning** — revise on failure instead of crashing.
 - **DAG task graphs** — model dependencies; run independent branches in parallel.
+
+**Interview questions:**
+1. **Plan-and-execute vs ReAct?** → Plan-and-execute drafts the full plan first (good for
+   complex, parallelizable tasks); ReAct interleaves reason/act step by step (good for
+   exploratory tasks where each step informs the next).
+2. **How should an agent handle a failed step?** → Replan: detect the failure, revise the
+   plan or retry with a different approach, rather than aborting.
+3. **Why represent tasks as a DAG?** → It captures dependencies and lets independent
+   subtasks run in parallel for speed.
 
 → **Deep dive:** [Agentic AI § Agent Patterns](./intro_agentic_ai.md) · [Multi-Agent Systems](./intro_multi_agent_systems.md)
 
 ## 13. Structured Outputs & Data Validation
 
-Force valid, typed data out of an LLM.
+**What it is.** Techniques to force an LLM to return **valid, typed, parseable** data (JSON
+matching a schema) instead of free text — essential when the output feeds code, a database,
+or another tool. Schema enforcement + validation + retry-on-failure makes the boundary reliable.
 
+**Key points:**
 - **Schema enforcement** — JSON-schema / strict tool mode guarantees parseable output.
 - **Pydantic + `instructor`** — define a model, get a validated object back.
-- **Output parsers** — coerce text → structured; handle partials.
 - **Retry on parse failure** — re-ask with the validation error so the model self-corrects.
+
+**Interview questions:**
+1. **How do you guarantee an LLM returns valid JSON?** → Use the provider's structured-
+   output/strict mode bound to a JSON schema, then validate; on failure, retry feeding back
+   the error.
+2. **What does the `instructor` library do?** → Wraps the LLM call so you get a validated
+   Pydantic object out, handling schema + retries.
+3. **Why validate model output at all?** → It's probabilistic text — without validation a
+   malformed field can crash or silently corrupt downstream code.
 
 → **Deep dive:** [Structured Outputs](./intro_structured_outputs.md) · [Pydantic](../frameworks/intro_pydantic.md)
 
 ## 14. Long-Context Management
 
-Stay within the window on long tasks.
+**What it is.** Keeping a long-running agent within the model's token budget. As history
+and tool outputs pile up, you must compress, summarize, or drop content while preserving the
+goal, key decisions, and open threads.
 
+**Key points:**
 - **Sliding window** — keep the most recent N turns.
-- **Summarization** — compress old history into a running summary (a "summarizer agent").
-- **Context compression** — drop low-value content; keep goals, decisions, open threads.
-- **Token budgeting** — allocate the window across system / history / retrieval / output; reserve headroom.
-- **Keep vs drop** — keep the task, constraints, and recent state; drop stale tool dumps.
+- **Summarization** — compress old history into a running summary.
+- **Context compression** — drop low-value content; keep goals/decisions/state.
+- **Token budgeting** — allocate the window across system / history / retrieval / output.
+
+**Interview questions:**
+1. **An agent's conversation exceeds the context window — what do you do?** → Summarize or
+   prune old turns (sliding window), retrieve only relevant context, and budget tokens; keep
+   the goal and recent state.
+2. **What do you keep vs drop when compressing context?** → Keep the task, constraints,
+   decisions, and current state; drop stale tool dumps and resolved sub-threads.
+3. **What is a summarizer agent?** → A sub-step/agent that condenses prior history into a
+   compact summary so the main agent stays within budget.
 
 → **Deep dive:** [Agentic AI § Context Management](./intro_agentic_ai.md) · [LLM Fundamentals § Token Budgeting](./intro_llm_fundamentals.md)
 
 ## 15. Agent State Management
 
-Persist and resume agents.
+**What it is.** Persisting an agent's working state — messages, plan, scratchpad, tool
+results — so it can be paused, resumed, recovered after a crash, or run statelessly across
+requests. Critical for long-running and production agents.
 
-- **Persisting state** — serialize messages, scratchpad, plan, and tool results.
+**Key points:**
+- **Persisting state** — serialize messages/plan/results to a store.
 - **Checkpointing** — snapshot at safe boundaries so a crash doesn't lose progress.
-- **Resuming** — rehydrate state and continue an interrupted task.
-- **Stateful vs stateless** — stateless scales easily but reloads context each call; stateful is cheaper per step but needs a store.
+- **Resuming** — rehydrate and continue an interrupted task.
+- **Stateful vs stateless** — stateless scales easily but reloads context; stateful is cheaper per step but needs a store.
+
+**Interview questions:**
+1. **How do you resume an interrupted agent?** → Checkpoint state at safe boundaries,
+   persist it, and on restart rehydrate and continue from the last checkpoint.
+2. **Stateful vs stateless agents — trade-off?** → Stateless is easy to scale horizontally
+   but reloads context each call; stateful is cheaper per step but needs durable storage and
+   careful concurrency.
+3. **What goes into an agent's serialized state?** → Message history, current plan/goal,
+   scratchpad/intermediate results, and any tool/session context needed to continue.
 
 → **Deep dive:** [Agentic AI § Production Agent Engineering](./intro_agentic_ai.md) · [LangGraph](./intro_langgraph.md)
 
@@ -283,85 +469,154 @@ Persist and resume agents.
 
 ## 16. LangGraph / Agent Workflows as Graphs
 
-Model agents as explicit state machines.
+**What it is.** Modeling an agent as an explicit **state machine / graph** rather than a
+free-form loop. Nodes do work, edges define transitions, conditionals branch on state, and
+cycles enable iterate-until-done — giving you controllable, debuggable, resumable agents.
 
-- **Nodes & edges** — nodes do work; edges define transitions.
-- **Conditional branching** — route based on state.
-- **Cycles** — loops enable iterate-until-done behavior.
-- **Human-in-the-loop nodes** — pause for approval/input.
-- **Parallel branches** — fan out independent work.
-- **Streaming state** — emit intermediate state for UX and debugging.
+**Key points:**
+- **Nodes & edges**, **conditional branching**, **cycles** (loops).
+- **Human-in-the-loop nodes** to pause for approval/input.
+- **Parallel branches**; **streaming state** for UX and debugging.
+
+**Interview questions:**
+1. **Why model an agent as a graph?** → Explicit control flow, deterministic branching,
+   built-in persistence/resumption, and easier debugging than an opaque loop.
+2. **How do cycles help in an agent graph?** → They let a node loop (retry/iterate) until a
+   condition is met — e.g., refine until the eval passes.
+3. **Where does human-in-the-loop fit in LangGraph?** → As a node that interrupts the graph
+   and waits for human input/approval before continuing.
 
 → **Deep dive:** [LangGraph](./intro_langgraph.md)
 
 ## 17. Human-in-the-Loop (HITL)
 
-Fully autonomous agents often fail in production — keep a human in the loop where it matters.
+**What it is.** Deliberately inserting human checkpoints into an agent's execution —
+approvals, edits, or escalation — because fully autonomous agents often fail on high-stakes
+or irreversible actions. The art is pausing only where it matters.
 
+**Key points:**
 - **When to pause** — irreversible/destructive actions, low confidence, high stakes.
 - **Interrupt mechanisms** — checkpoints where the agent yields control.
-- **Approval workflows** — explicit allow/deny on sensitive tool calls.
-- **Confidence thresholds** — auto-proceed above a bar, escalate below it.
-- **Async review** — queue for later human sign-off without blocking everything.
+- **Approval workflows** + **confidence thresholds** (auto-proceed above, escalate below).
+- **Async review** — queue for later sign-off without blocking.
+
+**Interview questions:**
+1. **When should an agent pause for a human?** → Before irreversible/destructive or
+   high-stakes actions, or when confidence is low — never for routine, reversible steps.
+2. **Why do fully autonomous agents fail in production?** → Compounding errors, edge cases,
+   and irreversible mistakes; a human checkpoint catches them before damage.
+3. **How do you decide what to auto-approve?** → A confidence threshold + a reversibility/
+   blast-radius check: auto-run cheap reversible actions, gate expensive irreversible ones.
 
 → **Deep dive:** [LangGraph (HITL nodes)](./intro_langgraph.md) · [Evaluation & Guardrails](../mlops/intro_evaluation_guardrails.md)
 
 ## 18. Tool Design & Tool Ecosystems
 
-Good tools make good agents.
+**What it is.** Designing the tools an agent uses so it picks and calls them correctly:
+clear names, strong "call this when…" descriptions, predictable typed outputs, and a
+manageable set. Bad tools (vague, overlapping, too many) are a top cause of agent failure.
 
-- **Design** — clear names, strong "call this when…" descriptions, predictable typed outputs.
-- **Tool libraries** — group by domain; a registry for discovery.
-- **Versioning** — evolve tools without breaking running agents.
-- **Composability** — small, single-purpose tools the agent can chain.
-- **Avoid tool overload** — too many tools hurts selection accuracy; use tool search / dynamic loading.
+**Key points:**
+- Clear names + prescriptive descriptions + predictable outputs.
+- Tool libraries with a registry; **versioning**; **composable** single-purpose tools.
+- **Avoid tool overload** — too many tools hurts selection; use tool search / dynamic loading.
+
+**Interview questions:**
+1. **What makes a good agent tool?** → A clear name, a description that says *when* to call
+   it, a strict typed schema, and predictable outputs that are easy to act on.
+2. **Why can too many tools hurt?** → It dilutes the model's selection accuracy and bloats
+   context; use tool search/dynamic discovery to load only relevant tools.
+3. **How do you evolve a tool without breaking running agents?** → Version it and keep old
+   versions available, or make changes backward-compatible.
 
 → **Deep dive:** [Agent Tool Use § Advanced Tool-Use Patterns](./intro_agent_tool_use.md)
 
 ## 19. Evaluation & Testing for Agents
 
-Standard unit tests don't cover non-determinism.
+**What it is.** Measuring whether an agent actually works — which standard unit tests can't,
+because agents are non-deterministic. You evaluate the **trajectory** (the path of decisions/
+tool calls) and outcomes against a curated task suite, often using an LLM as a judge.
 
-- **Why unit tests fall short** — same input ≠ same output; you test behavior distributions, not exact strings.
-- **Trajectory evaluation** — judge the *path* (tool choices, steps), not just the final answer.
-- **LLM-as-judge** — a model grades outputs against a rubric.
-- **Eval datasets** — curate task suites with success criteria.
-- **Regression testing** — re-run the suite on every change and on model upgrades.
-- **Cross-version benchmarking** — quantify quality/cost when you switch models.
+**Key points:**
+- **Why unit tests fall short** — same input ≠ same output; test distributions, not strings.
+- **Trajectory evaluation** — judge the path, not only the final answer.
+- **LLM-as-judge** — a model grades against a rubric.
+- **Eval datasets** + **regression testing** + **cross-version benchmarking**.
+
+**Interview questions:**
+1. **Why don't normal unit tests work for agents?** → Non-determinism — the same input can
+   yield different valid outputs; you must evaluate behavior distributions and trajectories.
+2. **What is trajectory evaluation?** → Grading the sequence of steps/tool calls (did it
+   take a sensible path?), not just the final output.
+3. **What is LLM-as-judge and its pitfall?** → Using a model to score outputs against a
+   rubric; the pitfall is judge bias/miscalibration — validate the judge against human labels.
+4. **How do you stop a model upgrade from regressing your agent?** → Run a fixed eval suite
+   on every change and gate on it (regression testing).
 
 → **Deep dive:** [LLM Evaluation](../mlops/intro_llm_evaluation.md) · [Testing AI Systems](../devops/intro_testing_ai.md)
 
 ## 20. Observability & Tracing
 
-You can't debug what you can't see.
+**What it is.** Instrumentation that lets you *see* what an agent did — every model call,
+tool call, and decision as a trace of spans — so you can debug failures, track cost/latency,
+and monitor quality in production. You can't debug what you can't see.
 
-- **Tools** — LangSmith, Langfuse, Arize Phoenix, OpenTelemetry (GenAI semantic conventions).
-- **End-to-end traces** — every model call, tool call, and decision as spans.
-- **Logging tool calls** — inputs, outputs, latency, errors.
-- **Debugging failures** — replay a trace to find where the agent went wrong.
-- **Cost & latency** — track tokens/cost/latency per run and per step.
+**Key points:**
+- **Tools** — LangSmith, Langfuse, Arize Phoenix, OpenTelemetry (GenAI conventions).
+- **End-to-end traces**, **logged tool calls**, **replayable failures**.
+- **Cost & latency** tracked per run and per step.
+
+**Interview questions:**
+1. **What do you trace in an agent run?** → Every model call (model, tokens, cost, latency),
+   every tool call (args, result, error), and the decisions/branches taken.
+2. **How do you debug a failed agent run?** → Pull the end-to-end trace, find the step that
+   went wrong (bad tool args, wrong branch, parse failure), and reproduce/fix it.
+3. **Why is per-run cost tracking important?** → Agentic features can blow up token spend;
+   per-run/per-step cost reveals outliers and unit economics.
 
 → **Deep dive:** [LangSmith](./intro_langsmith.md) · [LLMOps](./intro_llmops.md) · [Model Monitoring](../mlops/intro_model_monitoring.md)
 
 ## 21. Code Execution Agents
 
-Agents that write and run code.
+**What it is.** Agents that write and run code to solve tasks (data analysis, computation,
+file work). The code runs in a **sandbox** (E2B, Docker, gVisor, or a provider-hosted
+environment) — never on the host — because model-generated code is untrusted.
 
-- **Sandboxing** — E2B, Docker, gVisor, or provider-hosted code execution; never run model code on the host.
-- **Code interpreters** — model writes code → sandbox runs it → results return.
-- **Safety** — resource limits, network egress control, no host filesystem access, timeouts.
-- **Dangerous code** — allowlist/denylist, review gates for destructive ops.
+**Key points:**
+- **Sandboxing** — isolation, resource limits, no host filesystem, controlled egress, timeouts.
+- **Code interpreter loop** — model writes code → sandbox runs → result returns.
+- **Safety** — allowlist/denylist and review gates for destructive operations.
+
+**Interview questions:**
+1. **Why must code-execution agents be sandboxed?** → Model code is untrusted; a sandbox
+   contains it with resource/egress limits and no host access to prevent damage/exfiltration.
+2. **What sandboxing options exist?** → E2B, Docker/gVisor containers, microVMs, or a
+   provider-hosted code-execution tool.
+3. **How do you stop a code agent from doing damage?** → Network egress controls, no host
+   FS, CPU/mem/time limits, and human approval for destructive ops.
 
 → **Deep dive:** [Agent Tool Use § Server-Side Tools](./intro_agent_tool_use.md) · [Docker](../devops/intro_docker.md)
 
 ## 22. Browser & Computer Use Agents
 
-Agents that operate UIs.
+**What it is.** Agents that operate user interfaces — driving a browser (Playwright/
+Puppeteer) or a whole desktop. They either parse the DOM (precise, brittle) or work from
+screenshots with a vision model that emits mouse/keyboard actions (general, costlier).
 
-- **Web automation** — Playwright/Puppeteer drive real browsers.
-- **DOM vs screenshot** — parse the DOM (precise, brittle) vs vision-based screenshot interaction (general, costlier).
-- **Computer use** — vision models that take screenshots and emit mouse/keyboard actions.
-- **Edge cases** — CAPTCHAs, dynamic pages, auth, rate limits, flakiness.
+**Key points:**
+- **Web automation** via Playwright/Puppeteer.
+- **DOM vs screenshot/vision** trade-off.
+- **Computer use** — vision model takes screenshots, issues actions.
+- **Edge cases** — CAPTCHAs, dynamic pages, auth, flakiness, rate limits.
+
+**Interview questions:**
+1. **DOM parsing vs screenshot-based agents — trade-off?** → DOM is precise and cheap but
+   brittle to markup changes; vision/screenshot is general and robust to layout but slower,
+   costlier, and less exact.
+2. **What is "computer use"?** → A vision-capable model that views screenshots and emits
+   mouse/keyboard actions to operate a GUI like a human.
+3. **What makes browser agents flaky in production?** → Dynamic content, timing/race
+   conditions, auth, CAPTCHAs, and site changes — handle with waits, retries, and fallbacks.
 
 → **Deep dive:** [Testing AI Systems (Playwright/Puppeteer)](../devops/intro_testing_ai.md) · [Multimodal AI](./intro_multimodal_ai.md)
 
@@ -371,7 +626,9 @@ Agents that operate UIs.
 
 ## 23. Agent Reliability & Failure Modes
 
-Why agents fail — and how to contain it.
+**What it is.** Understanding *how* agents break in production and engineering so they fail
+gracefully, not catastrophically. Agentic systems compound small errors, so each failure
+mode needs a specific mitigation.
 
 | Failure mode | Mitigation |
 |--------------|-----------|
@@ -381,58 +638,108 @@ Why agents fail — and how to contain it.
 | Hallucinated tool calls | Strict schemas; validate before executing |
 | Context poisoning | Treat tool/retrieved content as untrusted data |
 
+**Interview questions:**
+1. **What are the most common ways agents fail in production?** → Prompt brittleness, tool
+   failures cascading, infinite loops, hallucinated/invalid tool calls, and context poisoning.
+2. **What is context poisoning?** → When malicious or wrong content enters the context (via
+   a tool/retrieval) and corrupts subsequent behavior — mitigate by treating it as untrusted data.
+3. **How do you make an agent fail gracefully?** → Budgets/caps, tool-error handling with
+   fallbacks, HITL on irreversible actions, and circuit breakers.
+
 → **Deep dive:** [Agentic AI § Failure Modes & Guardrails](./intro_agentic_ai.md) · [Evaluation & Guardrails](../mlops/intro_evaluation_guardrails.md)
 
 ## 24. Latency Optimization
 
-Make agents feel fast.
+**What it is.** Making agents feel fast despite multiple sequential model/tool calls.
+Techniques range from streaming output to users, to parallelizing calls, to routing
+sub-tasks to faster models and caching.
 
-- **Streaming** — show tokens/progress during the run.
-- **Parallel tool calls** — execute independent tools concurrently.
-- **Smaller models for sub-tasks** — route routing/extraction to a fast tier.
-- **Caching** — prompt caching of the stable prefix; cache deterministic tool results.
-- **Speculative execution / prefetching** — start likely-needed work early.
+**Key points:**
+- **Streaming**, **parallel tool calls**, **smaller models for sub-tasks**.
+- **Caching** (prompt-cache the stable prefix; cache deterministic tool results).
+- **Speculative execution / prefetching** of likely-needed work.
+
+**Interview questions:**
+1. **An agent feels slow — where do you start?** → Trace the latency-critical path;
+   parallelize independent calls, stream output, route sub-tasks to faster models, and cache.
+2. **How does prompt caching cut latency and cost?** → A cached stable prefix skips
+   reprocessing (and bills ~10× less on reads), reducing time-to-first-token.
+3. **What is speculative execution for agents?** → Starting likely-needed work (e.g., a
+   probable tool call) before it's confirmed, to hide latency.
 
 → **Deep dive:** [Agentic AI § Cost & Latency](./intro_agentic_ai.md) · [LLM Fundamentals § Prompt Caching](./intro_llm_fundamentals.md)
 
 ## 25. Cost Management at Scale
 
-Unit economics decide whether the feature survives.
+**What it is.** Controlling the token spend of agentic features so the unit economics work.
+Agents make many calls, so cost is dominated by model choice, prompt size, and number of
+steps — all of which you can manage.
 
-- **Token budgeting** — cap input/output per task.
-- **Model routing** — cheap model by default, escalate to a frontier model only when needed.
-- **Prompt compression & caching** — shrink and reuse the stable prefix (~10× cheaper cache reads).
-- **Cost per task** — monitor it; alert on outliers.
-- **Unit economics** — know the $/task and whether it's sustainable at your usage.
+**Key points:**
+- **Token budgeting**, **model routing** (cheap by default, escalate when needed).
+- **Prompt compression & caching** (~10× cheaper cache reads).
+- **Cost per task** monitoring; know your **unit economics**.
+
+**Interview questions:**
+1. **Biggest lever on LLM cost at scale?** → Prompt caching of the stable prefix plus
+   right-sizing the model per task (model routing).
+2. **What is model routing?** → Sending each request to the cheapest model that can handle
+   it, escalating to a frontier model only for hard cases.
+3. **How do you estimate an agent's cost before building?** → tokens × price per step ×
+   expected steps, across the trajectory, plus retries.
 
 → **Deep dive:** [LLM Fundamentals § Estimating Cost](./intro_llm_fundamentals.md) · [Multi-Model Orchestration](./intro_multi_model_orchestration.md)
 
 ## 26. Security for Agentic Systems
 
-Agents with tools are an attack surface.
+**What it is.** Defending agents that can take actions. The signature threat is **prompt
+injection** — including **indirect** injection where malicious instructions hide inside
+retrieved documents or tool outputs. Combined with tools and credentials, an injected agent
+can do real damage, so least-privilege and sandboxing are essential.
 
-- **Prompt injection** — direct (user) and **indirect** (malicious content inside retrieved docs/tool outputs).
-- **Privilege escalation** — agents should have least-privilege tool/credential access.
-- **Sandboxing** — isolate code/tool execution.
-- **Permissions** — what an agent should *never* be able to do (delete prod, move money) without HITL.
-- **Data exfiltration** — guard against an injected instruction leaking secrets via a tool call.
+**Key points:**
+- **Direct vs indirect prompt injection.**
+- **Least-privilege** tool/credential access; **sandboxing**.
+- **Permissions** — what an agent must never do without HITL.
+- **Data exfiltration** risk via tool calls.
+
+**Interview questions:**
+1. **What is indirect prompt injection?** → Malicious instructions embedded in content the
+   agent ingests (a web page, a document, a tool result) that hijack its behavior.
+2. **How do you defend against prompt injection?** → Treat all tool/retrieved content as
+   untrusted data (never instructions), least-privilege tools, sandboxing, output filtering,
+   and HITL on sensitive actions.
+3. **Why is least privilege critical for agents?** → It bounds the blast radius — an
+   injected/compromised agent can only do what its limited permissions allow.
 
 → **Deep dive:** [LLM Security](./intro_llm_security.md)
 
 ## 27. Deployment Patterns
 
-Get the agent off your laptop.
+**What it is.** How you run agents in production. Short tasks fit serverless functions;
+stateful/streaming agents need long-running services; durable jobs use queues; event-driven
+agents trigger on webhooks — all typically containerized and horizontally scaled.
 
-- **Serverless vs long-running** — serverless functions for short tasks; long-running services for stateful/streaming agents.
-- **Queue-based execution** — Celery / SQS / Cloud Tasks for durable, retryable agent jobs.
-- **Webhook-driven** — trigger agents on events.
-- **Containerization** — package the agent + deps in Docker; scale horizontally on Kubernetes.
+**Key points:**
+- **Serverless vs long-running** services.
+- **Queue-based** execution (Celery, SQS, Cloud Tasks) for durable retryable jobs.
+- **Webhook-driven** agents; **containerization** + horizontal scaling.
+
+**Interview questions:**
+1. **Serverless vs long-running service for an agent?** → Serverless for short, stateless
+   tasks; a long-running service for stateful, streaming, or long-horizon agents.
+2. **Why run agents through a queue?** → Durability, retries, backpressure, and decoupling —
+   so a slow/failed agent job doesn't drop work or block the caller.
+3. **How do you scale agents horizontally?** → Containerize, keep them stateless (or
+   externalize state), and run many workers behind a queue/load balancer.
 
 → **Deep dive:** [Backend & System Design for AI](../system_design/intro_backend_ai_system_design.md) · [Docker](../devops/intro_docker.md) · [Kubernetes](../devops/intro_kubernetes.md) · [FastAPI](../frameworks/intro_fastapi.md)
 
 ## 28. Agentic Architecture Patterns
 
-Knowing which pattern fits which problem separates seniors from juniors.
+**What it is.** Reusable high-level designs for structuring agentic systems. Recognizing
+which pattern fits a problem class — and the trade-offs — is what distinguishes senior from
+junior engineers.
 
 | Pattern | Use when |
 |---------|----------|
@@ -443,6 +750,14 @@ Knowing which pattern fits which problem separates seniors from juniors.
 | **Hub-and-spoke** | Central router to many tools/agents |
 | **Map-reduce** | Fan out over items, aggregate results |
 
+**Interview questions:**
+1. **Which pattern for "summarize 10,000 documents"?** → Map-reduce: fan out summarization
+   over chunks/docs in parallel, then reduce/aggregate.
+2. **When is a simple pipeline better than a dynamic agent?** → When the steps are fixed and
+   fully specifiable — it's cheaper, faster, and more reliable than a free-roaming agent.
+3. **What is the blackboard pattern?** → Agents read/write a shared workspace; each
+   contributes when it can, useful for collaborative problem-solving without rigid order.
+
 → **Deep dive:** [ML System Design Patterns](../system_design/ml_system_design_patterns.md) · [Multi-Agent Systems](./intro_multi_agent_systems.md)
 
 ---
@@ -451,72 +766,135 @@ Knowing which pattern fits which problem separates seniors from juniors.
 
 ## 29. Fine-tuning for Agentic Behavior
 
-When prompting isn't enough.
+**What it is.** Training a model (or adapter) on agent data when prompting hits a ceiling —
+to bake in consistent tool-use behavior, niche formats, or to make a smaller, cheaper model
+behave like a larger one. Done via SFT on trajectories, DPO on preferences, and LoRA/QLoRA
+for cheap iteration.
 
-- **When fine-tuning beats prompting** — consistent niche behavior, latency/cost wins from a smaller tuned model, hard-to-prompt formats.
-- **SFT on trajectories** — supervised fine-tuning on successful agent runs.
-- **DPO for tool-use preferences** — preference-optimize toward good tool choices.
-- **Datasets from runs** — mine successful trajectories as training data.
-- **LoRA / QLoRA** — parameter-efficient tuning for fast, cheap iteration.
+**Key points:**
+- **When it beats prompting** — consistent niche behavior, cost/latency wins, hard-to-prompt formats.
+- **SFT on trajectories**, **DPO for tool-use preferences**.
+- **Datasets from successful runs**; **LoRA/QLoRA** for fast, cheap tuning.
+
+**Interview questions:**
+1. **When do you fine-tune instead of prompt?** → When prompting can't get consistent
+   behavior, when a tuned small model is cheaper/faster at scale, or for formats/domains hard
+   to express in a prompt.
+2. **Where does training data for an agent come from?** → Successful agent trajectories
+   (SFT) and preference pairs of good vs bad actions (DPO).
+3. **What is LoRA and why use it?** → Low-Rank Adaptation trains small adapter weights
+   instead of the full model — far cheaper/faster, enabling quick iteration.
 
 → **Deep dive:** [Fine-Tuning (LoRA, QLoRA, RLHF/DPO)](../deep_learning/intro_fine_tuning.md) · [Unsloth](../frameworks/intro_unsloth.md)
 
 ## 30. Reasoning Models
 
-Models that "think" at inference time.
+**What it is.** Models trained (often with RL) to produce a long internal chain of thought
+*at inference time* before answering — spending extra compute to solve hard reasoning/
+planning problems. Anthropic exposes this idea as **adaptive thinking + an effort control**.
 
-- **How they work** — trained (often with RL) to produce long internal chains of thought before answering; spend more compute on hard problems.
-- **When to use** — genuinely hard reasoning/planning; not for simple lookups (slower, costlier).
-- **Cost/latency** — reasoning tokens add latency and cost; gate them behind difficulty.
-- **In agent pipelines** — use a reasoning model for the planner/orchestrator, a fast model for routine sub-steps. Anthropic's **adaptive thinking + effort** controls are this idea exposed as parameters.
+**Key points:**
+- **How they work** — extended internal reasoning before the final answer.
+- **When to use** — genuinely hard reasoning/planning; not simple lookups.
+- **Cost/latency** — reasoning tokens add both; gate them behind difficulty.
+- **In pipelines** — reasoning model for the planner, fast model for routine sub-steps.
+
+**Interview questions:**
+1. **What is a reasoning model?** → One trained to "think" (generate long internal reasoning)
+   before answering, trading inference compute/latency for accuracy on hard problems.
+2. **When should you NOT use a reasoning model?** → Simple/fast tasks (classification,
+   extraction, lookups) — it's slower and costlier with no benefit.
+3. **How do you combine reasoning and fast models in an agent?** → Use the reasoning model
+   for planning/hard steps and a fast/cheap model for routine sub-tasks (model routing).
 
 → **Deep dive:** [Anthropic & Claude (extended/adaptive thinking)](./intro_anthropic.md) · [LLM Fundamentals](./intro_llm_fundamentals.md)
 
 ## 31. Multi-Modal Agents
 
-Beyond text.
+**What it is.** Agents that work across modalities beyond text — vision (images, documents,
+charts), audio, and image generation — using multi-modal models and tools, with memory that
+can span modalities.
 
-- **Vision + text** — reason over images alongside text.
-- **Document understanding** — PDFs, tables, charts, scans.
-- **Audio** — speech-to-text input (and TTS output).
-- **Image generation as a tool** — call a generator from the agent.
-- **Multi-modal memory** — store and retrieve across modalities.
+**Key points:**
+- **Vision + text** reasoning; **document understanding** (PDFs, tables, charts).
+- **Audio** input (STT) and output (TTS); **image generation as a tool**.
+- **Multi-modal memory** — store/retrieve across modalities.
+
+**Interview questions:**
+1. **What is a multi-modal agent?** → One that perceives/acts across modalities (text +
+   vision + audio), e.g., reading a chart in a PDF and reasoning over it.
+2. **How do agents handle documents like PDFs with tables/charts?** → Vision-capable models
+   parse layout/tables/figures directly, often combined with OCR/extraction tools.
+3. **How is image generation used in an agent?** → As a tool the agent calls to produce
+   images as part of a task.
 
 → **Deep dive:** [Multimodal AI](./intro_multimodal_ai.md) · [Computer Vision](../deep_learning/intro_computer_vision.md)
 
 ## 32. Agent Communication Standards
 
-The emerging interoperability layer.
+**What it is.** Emerging protocols that let agents and tools interoperate across vendors.
+**MCP** standardizes agent↔tool/data communication; **A2A (Agent-to-Agent)**, from Google,
+standardizes agent↔agent communication — together avoiding bespoke N×M integrations as
+multi-agent ecosystems grow.
 
-- **MCP** — standard for agent↔tool/resource communication (tool ecosystem).
-- **A2A (Agent-to-Agent)** — Google's protocol for agent↔agent interoperability.
-- **Interoperable agents** — agents from different vendors cooperating via shared protocols.
-- **Registries & discovery** — find and describe available agents/tools.
-- **Why it matters** — avoids N×M bespoke integrations as the ecosystem grows.
+**Key points:**
+- **MCP** — agent↔tool/resource standard (tool ecosystem).
+- **A2A** — agent↔agent interoperability (Google).
+- **Registries & discovery**; interoperable agents across vendors.
+
+**Interview questions:**
+1. **MCP vs A2A?** → MCP standardizes how an agent talks to *tools/data*; A2A standardizes
+   how agents talk to *each other*.
+2. **Why do we need agent communication standards?** → To avoid bespoke per-pair
+   integrations and enable agents/tools from different vendors to interoperate.
+3. **What is agent discovery?** → A mechanism (registry/protocol) for an agent to find and
+   learn the capabilities of available agents/tools at runtime.
 
 → **Deep dive:** [MCP](./intro_mcp.md)
 
 ## 33. Building Agent Platforms
 
-Infrastructure so *other* teams can ship agents.
+**What it is.** Going beyond a single agent to build the *infrastructure* other teams use to
+deploy agents safely: SDKs, multi-tenant isolation, permissioning, registries/marketplaces,
+and audit logging. This is platform engineering applied to agents.
 
-- **Agent SDKs** — give teams a paved path to define agents.
-- **Multi-tenant isolation** — separate state, secrets, and compute per tenant.
-- **Permissioning** — scoped tool/credential access per agent/tenant.
-- **Marketplaces & registries** — discover and reuse agents/tools.
-- **Audit logs** — every action traceable for compliance and debugging.
+**Key points:**
+- **Agent SDKs** — a paved path for teams to define agents.
+- **Multi-tenant isolation** — separate state/secrets/compute per tenant.
+- **Permissioning** — scoped tool/credential access; **audit logs** for every action.
+
+**Interview questions:**
+1. **What does an agent *platform* provide beyond a single agent?** → SDKs, multi-tenant
+   isolation, permissioning, registries, observability, and audit logs so many teams can ship
+   agents safely.
+2. **How do you isolate tenants on an agent platform?** → Separate state stores, scoped
+   credentials/secrets, network isolation, and per-tenant resource/permission boundaries.
+3. **Why are audit logs essential?** → Agents take actions; you need a traceable record for
+   debugging, compliance, and incident response.
 
 → **Deep dive:** [Backend & System Design for AI](../system_design/intro_backend_ai_system_design.md) · [LLMOps / MLOps Engineering](../mlops/intro_llmops_mlops_engineering.md)
 
 ## 34. Self-Improving Agents / Meta-Agents
 
-Agents that improve agents.
+**What it is.** Agents that improve agents — by optimizing their own prompts against evals,
+red-teaming other agents, generating/testing new agents, or running reflection (critique-and-
+revise) loops. **Constitutional AI** is a related idea: steering behavior with a set of
+principles rather than only human labels.
 
-- **Prompt self-optimization** — agents that rewrite and test their own prompts against evals.
-- **Automated red-teaming** — agents that attack agents to find failures.
-- **Agents that build agents** — generate, test, and refine other agents.
-- **Reflection loops** — critique-and-revise to improve outputs.
-- **Constitutional AI** — train/steer behavior against a set of principles rather than only human labels.
+**Key points:**
+- **Prompt self-optimization** against an eval set.
+- **Automated red-teaming**; **agents that build/test agents**.
+- **Reflection loops** (critique → revise).
+- **Constitutional AI** — principle-based steering.
+
+**Interview questions:**
+1. **What is a reflection loop?** → An agent critiques its own output against criteria and
+   revises — iterating until it meets the bar.
+2. **What is a meta-agent?** → An agent whose job is to create, evaluate, or improve other
+   agents (or prompts), rather than do the end task directly.
+3. **What is Constitutional AI?** → Training/steering a model to follow a set of written
+   principles (a "constitution") to be helpful, harmless, and honest, reducing reliance on
+   per-case human labels.
 
 → **Deep dive:** [LLM Evaluation](../mlops/intro_llm_evaluation.md) · [Anthropic (Constitutional AI)](./intro_anthropic.md)
 

--- a/ai_genai/intro_agentic_ai_engineering_roadmap.md
+++ b/ai_genai/intro_agentic_ai_engineering_roadmap.md
@@ -1,0 +1,551 @@
+# The Agentic AI Engineer Roadmap (2026 Edition)
+
+A complete, layered curriculum for becoming a production-grade **Agentic AI
+Engineer** — from Python foundations to frontier topics like agent platforms and
+self-improving agents. Each topic gives you the concept, why it matters, the key
+things to know, and a **→ Deep dive** link to the in-repo guide that covers it in
+full.
+
+> **How to use this:** Work top-to-bottom. The layers are ordered by dependency —
+> you genuinely need the Foundation layer before the Core Agentic layer, and so on.
+> The final section, [What Actually Gets You Hired](#what-actually-gets-you-hired),
+> is what senior interviews really probe.
+
+---
+
+## Table of Contents
+
+**Foundation Layer**
+1. [Python for AI Engineering](#1-python-for-ai-engineering)
+2. [LLM Fundamentals](#2-llm-fundamentals)
+3. [Prompt Engineering](#3-prompt-engineering)
+4. [LLM APIs](#4-llm-apis)
+
+**Core Agentic Layer**
+5. [Tool Use / Function Calling](#5-tool-use--function-calling)
+6. [Agent Loops](#6-agent-loops)
+7. [Memory Systems](#7-memory-systems)
+8. [RAG](#8-rag-retrieval-augmented-generation)
+9. [Frameworks](#9-frameworks-langchain--llamaindex--crewai--autogen)
+
+**Intermediate Agentic Layer**
+10. [Multi-Agent Systems](#10-multi-agent-systems)
+11. [MCP](#11-mcp-model-context-protocol)
+12. [Planning & Task Decomposition](#12-planning--task-decomposition)
+13. [Structured Outputs & Validation](#13-structured-outputs--data-validation)
+14. [Long-Context Management](#14-long-context-management)
+15. [Agent State Management](#15-agent-state-management)
+
+**Advanced Agentic Layer**
+16. [LangGraph / Workflows as Graphs](#16-langgraph--agent-workflows-as-graphs)
+17. [Human-in-the-Loop](#17-human-in-the-loop-hitl)
+18. [Tool Design & Ecosystems](#18-tool-design--tool-ecosystems)
+19. [Evaluation & Testing](#19-evaluation--testing-for-agents)
+20. [Observability & Tracing](#20-observability--tracing)
+21. [Code Execution Agents](#21-code-execution-agents)
+22. [Browser & Computer Use](#22-browser--computer-use-agents)
+
+**Production & Senior Layer**
+23. [Reliability & Failure Modes](#23-agent-reliability--failure-modes)
+24. [Latency Optimization](#24-latency-optimization)
+25. [Cost Management at Scale](#25-cost-management-at-scale)
+26. [Security for Agentic Systems](#26-security-for-agentic-systems)
+27. [Deployment Patterns](#27-deployment-patterns)
+28. [Agentic Architecture Patterns](#28-agentic-architecture-patterns)
+
+**Expert / Frontier Layer**
+29. [Fine-tuning for Agentic Behavior](#29-fine-tuning-for-agentic-behavior)
+30. [Reasoning Models](#30-reasoning-models)
+31. [Multi-Modal Agents](#31-multi-modal-agents)
+32. [Agent Communication Standards](#32-agent-communication-standards)
+33. [Building Agent Platforms](#33-building-agent-platforms)
+34. [Self-Improving Agents / Meta-Agents](#34-self-improving-agents--meta-agents)
+
+- [What Actually Gets You Hired](#what-actually-gets-you-hired)
+
+---
+
+# Foundation Layer
+
+## 1. Python for AI Engineering
+
+The non-negotiable base. You need this before everything else.
+
+- **Core Python** — data structures, comprehensions, generators, context managers, decorators.
+- **`async`/`await`** — concurrent API calls (agents make *many*); `asyncio.gather` to parallelize tool calls and model requests.
+- **Type hints** — `list[str]`, `dict[str, Any]`, `Optional`, `Literal`, generics; they make agent code maintainable and power schema generation.
+- **Pydantic models** — typed, validated data; the backbone of structured outputs and tool schemas.
+- **Environment management** — `venv`/`uv`/`poetry`, `.env` files, never hardcoding keys.
+- **Working with APIs** — `requests`/`httpx`, retries, timeouts, pagination, streaming.
+- **Error handling & logging** — typed exceptions, retry/backoff, structured logging with correlation IDs (essential for debugging non-deterministic agents).
+
+→ **Deep dive:** [Python for AI Engineering](../frameworks/intro_python_for_ai.md) ·
+[Pydantic](../frameworks/intro_pydantic.md) · [FastAPI](../frameworks/intro_fastapi.md)
+
+## 2. LLM Fundamentals
+
+How the thing you're orchestrating actually behaves.
+
+- **Transformers (conceptual)** — self-attention lets every token attend to every other; decoder-only models predict the next token autoregressively.
+- **Tokens & context windows** — text → tokens (~4 chars each); the window caps input+output. Budget it.
+- **Sampling** — `temperature` (randomness) and `top_p` (nucleus) trade determinism for creativity; low for extraction/code, higher for ideation.
+- **System vs user prompts** — system sets persona/rules/constraints (higher authority); user carries the task.
+- **Few-shot prompting** — examples in the prompt steer format and behavior without fine-tuning.
+- **Prompt injection (basics)** — untrusted text can hijack instructions; never trust retrieved/tool content as commands.
+
+→ **Deep dive:** [LLM Fundamentals](./intro_llm_fundamentals.md) · [Transformers](../deep_learning/intro_transformers.md)
+
+## 3. Prompt Engineering
+
+The cheapest, fastest lever on agent quality.
+
+- **Chain-of-Thought (CoT)** — "think step by step" for multi-step reasoning.
+- **Zero-shot vs few-shot** — no examples vs a handful of worked examples.
+- **Structured-output prompting** — ask for JSON/XML; pair with schema enforcement.
+- **Role prompting** — assign an expert persona to shape tone and rigor.
+- **ReAct (Reason + Act)** — interleave reasoning traces with tool actions — the canonical agent prompting pattern.
+- **XML/JSON coercion** — wrap fields in tags/keys the model reliably emits; parse defensively.
+- **Hallucination control** — ground with retrieval, demand citations, lower temperature, allow "I don't know."
+
+→ **Deep dive:** [Prompt Engineering](./intro_prompt_engineering.md)
+
+## 4. LLM APIs
+
+OpenAI, Anthropic, and Google — calling them well.
+
+- **Calling them** — all expose a chat/messages endpoint; you send messages + params and get content blocks back.
+- **Streaming** — Server-Sent Events deliver tokens incrementally; essential for UX and to avoid request timeouts on long outputs.
+- **Rate limits** — RPM/TPM caps; handle `429` with exponential backoff (SDKs retry automatically).
+- **Token counting** — use the **provider's own** counter (not `tiktoken` for Claude — it undercounts).
+- **Error handling** — typed exceptions; retry 429/5xx, don't retry 4xx.
+- **Model tiers (cost vs capability)** — frontier (hardest reasoning), balanced workhorse, fast/cheap. Route by task.
+
+| Provider | Frontier / reasoning | Balanced | Fast / cheap |
+|----------|----------------------|----------|--------------|
+| Anthropic | `claude-fable-5`, `claude-opus-4-8` | `claude-sonnet-4-6` | `claude-haiku-4-5` |
+| OpenAI | GPT frontier tier | GPT mid tier | GPT mini/nano tier |
+| Google | Gemini Pro/Ultra tier | Gemini Flash | Gemini Flash-Lite |
+
+> Always confirm current model IDs and pricing from each provider's docs — they change frequently.
+
+→ **Deep dive:** [Anthropic & Claude API](./intro_anthropic.md) · [Multi-Model Orchestration](./intro_multi_model_orchestration.md)
+
+---
+
+# Core Agentic Layer
+
+## 5. Tool Use / Function Calling
+
+The heartbeat of agentic systems.
+
+- **How it works** — you pass tool definitions (name, description, JSON schema); the model returns a *tool-use request* with arguments; you execute it and feed the **tool result** back into context; repeat.
+- **JSON schemas** — `type: object`, typed properties, `required`, `enum`; use strict mode (`additionalProperties: false`) for guaranteed-valid args.
+- **Parsing responses** — read tool-use blocks, match each by `tool_use_id`.
+- **Multi-tool calls in one turn** — execute independent calls in parallel; return **all** results in **one** message.
+- **Result injection** — append the assistant turn (with tool-use blocks) *then* the tool results, so the model can continue.
+
+→ **Deep dive:** [Agent Systems & Tool Use](./intro_agent_tool_use.md)
+
+## 6. Agent Loops
+
+The engine: **observe → think → act → observe**.
+
+- **Minimal ReAct loop** — call model → if it requests a tool, run it, append result, loop; else stop.
+- **Stopping conditions** — `end_turn`, goal reached, or a max-iteration / token budget.
+- **Handling stalls** — detect repeated states/loops; add a "if stuck, ask for help or stop" instruction; cap retries.
+- **Manual vs SDK-driven** — write the loop yourself for approval gates and custom logging; use an SDK tool runner for the common case.
+
+→ **Deep dive:** [Agentic AI](./intro_agentic_ai.md) (§ Agent Patterns, § Production Agent Engineering)
+
+## 7. Memory Systems
+
+What the agent remembers, and where.
+
+| Memory type | What it holds | Backed by |
+|-------------|---------------|-----------|
+| **In-context (working)** | Current window contents | The prompt itself |
+| **Episodic** | Conversation/run history | Message log, DB |
+| **Semantic** | Facts & knowledge | Vector store (RAG) |
+| **Procedural** | How-to / skills | Tools, prompts, skill files |
+| **External / long-term** | Anything beyond the window | Vector DB, SQL, files |
+
+- **When to use each** — keep hot context in-window; offload facts to a vector store; persist run history for resumption; encode procedures as tools/skills.
+- **Trade-offs** — more in-context memory = higher cost/latency; retrieve selectively.
+
+→ **Deep dive:** [Agentic AI § Agent Memory](./intro_agentic_ai.md) · [Vector Databases](./intro_vector_databases.md)
+
+## 8. RAG (Retrieval-Augmented Generation)
+
+Ground answers in your data instead of model memory.
+
+- **Chunking** — size + overlap; semantic/recursive splitting beats fixed windows; respect document structure.
+- **Embedding models** — turn text into vectors; pick by domain, dimension, cost.
+- **Vector databases** — Pinecone, Weaviate, Chroma, pgvector, FAISS.
+- **Similarity search** — cosine/dot-product top-k retrieval.
+- **Hybrid search** — combine BM25 (lexical) + dense (semantic) for recall on rare terms.
+- **Reranking** — a cross-encoder reorders candidates for precision before they hit the prompt.
+- **Context stuffing vs retrieval** — stuff when the corpus is tiny; retrieve when it's large.
+
+→ **Deep dive:** [RAG](./intro_rag.md) · [RAG Engineering](./intro_rag_engineering.md) · [Vector Databases — Advanced](./intro_vector_databases_advanced.md)
+
+## 9. Frameworks: LangChain / LlamaIndex / CrewAI / AutoGen
+
+Deeply understand **at least one** — and know its limits.
+
+| Framework | Sweet spot |
+|-----------|-----------|
+| **LangChain / LangGraph** | General LLM apps; LangGraph for stateful graph agents |
+| **LlamaIndex** | Data-centric RAG and indexing |
+| **CrewAI** | Role-based multi-agent "crews" |
+| **AutoGen** | Conversational multi-agent (Microsoft) |
+
+- **What they provide** — prompt/chain abstractions, tool integrations, memory, retrievers, orchestration.
+- **What they hide** — the raw API loop, exact prompts, token usage; debugging through layers is harder.
+- **When they help vs hurt** — great for fast prototypes and standard patterns; raw SDK often wins for fine-grained control, performance, and cost transparency. Senior engineers can articulate this trade-off.
+
+→ **Deep dive:** [LangChain](./intro_langchain.md) · [LangGraph](./intro_langgraph.md) · [CrewAI](./intro_crewai.md) · [LangChain LCEL/Advanced](../frameworks/intro_langchain.md)
+
+---
+
+# Intermediate Agentic Layer
+
+## 10. Multi-Agent Systems
+
+Multiple specialized agents beat one generalist.
+
+- **Orchestrator–worker** — a coordinator delegates subtasks to specialized workers.
+- **Supervisor pattern** — a supervisor routes, monitors, and aggregates.
+- **Delegation & shared state** — pass context explicitly; agents don't share memory unless you wire it.
+- **Communication protocols** — message passing, structured handoffs, blackboard.
+- **Why specialize** — focused prompts/tools per role → higher reliability than one overloaded agent.
+
+→ **Deep dive:** [Multi-Agent Systems](./intro_multi_agent_systems.md)
+
+## 11. MCP (Model Context Protocol)
+
+Anthropic's open standard for agent↔tool communication.
+
+- **MCP servers** — expose tools/resources/prompts over a standard protocol.
+- **Building tools** — implement a server once; any MCP-aware agent can use it.
+- **Connecting agents** — declare the server; the agent gains its tools without bespoke integration.
+- **Tool discovery** — clients enumerate a server's capabilities at runtime.
+
+→ **Deep dive:** [MCP](./intro_mcp.md) · [Agent Communication Standards](#32-agent-communication-standards)
+
+## 12. Planning & Task Decomposition
+
+Break a goal into executable steps.
+
+- **Plan-and-execute** — generate a plan, then execute steps (vs reactive ReAct).
+- **Hierarchical planning** — high-level plan → sub-plans → actions.
+- **Replanning** — when a step fails, revise the plan rather than crashing.
+- **DAG task graphs** — model dependencies; run independent branches in parallel.
+
+→ **Deep dive:** [Agentic AI § Agent Patterns](./intro_agentic_ai.md) · [Multi-Agent Systems](./intro_multi_agent_systems.md)
+
+## 13. Structured Outputs & Data Validation
+
+Force valid, typed data out of an LLM.
+
+- **Schema enforcement** — JSON-schema / strict tool mode guarantees parseable output.
+- **Pydantic + `instructor`** — define a model, get a validated object back.
+- **Output parsers** — coerce text → structured; handle partials.
+- **Retry on parse failure** — re-ask with the validation error so the model self-corrects.
+
+→ **Deep dive:** [Structured Outputs](./intro_structured_outputs.md) · [Pydantic](../frameworks/intro_pydantic.md)
+
+## 14. Long-Context Management
+
+Stay within the window on long tasks.
+
+- **Sliding window** — keep the most recent N turns.
+- **Summarization** — compress old history into a running summary (a "summarizer agent").
+- **Context compression** — drop low-value content; keep goals, decisions, open threads.
+- **Token budgeting** — allocate the window across system / history / retrieval / output; reserve headroom.
+- **Keep vs drop** — keep the task, constraints, and recent state; drop stale tool dumps.
+
+→ **Deep dive:** [Agentic AI § Context Management](./intro_agentic_ai.md) · [LLM Fundamentals § Token Budgeting](./intro_llm_fundamentals.md)
+
+## 15. Agent State Management
+
+Persist and resume agents.
+
+- **Persisting state** — serialize messages, scratchpad, plan, and tool results.
+- **Checkpointing** — snapshot at safe boundaries so a crash doesn't lose progress.
+- **Resuming** — rehydrate state and continue an interrupted task.
+- **Stateful vs stateless** — stateless scales easily but reloads context each call; stateful is cheaper per step but needs a store.
+
+→ **Deep dive:** [Agentic AI § Production Agent Engineering](./intro_agentic_ai.md) · [LangGraph](./intro_langgraph.md)
+
+---
+
+# Advanced Agentic Layer
+
+## 16. LangGraph / Agent Workflows as Graphs
+
+Model agents as explicit state machines.
+
+- **Nodes & edges** — nodes do work; edges define transitions.
+- **Conditional branching** — route based on state.
+- **Cycles** — loops enable iterate-until-done behavior.
+- **Human-in-the-loop nodes** — pause for approval/input.
+- **Parallel branches** — fan out independent work.
+- **Streaming state** — emit intermediate state for UX and debugging.
+
+→ **Deep dive:** [LangGraph](./intro_langgraph.md)
+
+## 17. Human-in-the-Loop (HITL)
+
+Fully autonomous agents often fail in production — keep a human in the loop where it matters.
+
+- **When to pause** — irreversible/destructive actions, low confidence, high stakes.
+- **Interrupt mechanisms** — checkpoints where the agent yields control.
+- **Approval workflows** — explicit allow/deny on sensitive tool calls.
+- **Confidence thresholds** — auto-proceed above a bar, escalate below it.
+- **Async review** — queue for later human sign-off without blocking everything.
+
+→ **Deep dive:** [LangGraph (HITL nodes)](./intro_langgraph.md) · [Evaluation & Guardrails](../mlops/intro_evaluation_guardrails.md)
+
+## 18. Tool Design & Tool Ecosystems
+
+Good tools make good agents.
+
+- **Design** — clear names, strong "call this when…" descriptions, predictable typed outputs.
+- **Tool libraries** — group by domain; a registry for discovery.
+- **Versioning** — evolve tools without breaking running agents.
+- **Composability** — small, single-purpose tools the agent can chain.
+- **Avoid tool overload** — too many tools hurts selection accuracy; use tool search / dynamic loading.
+
+→ **Deep dive:** [Agent Tool Use § Advanced Tool-Use Patterns](./intro_agent_tool_use.md)
+
+## 19. Evaluation & Testing for Agents
+
+Standard unit tests don't cover non-determinism.
+
+- **Why unit tests fall short** — same input ≠ same output; you test behavior distributions, not exact strings.
+- **Trajectory evaluation** — judge the *path* (tool choices, steps), not just the final answer.
+- **LLM-as-judge** — a model grades outputs against a rubric.
+- **Eval datasets** — curate task suites with success criteria.
+- **Regression testing** — re-run the suite on every change and on model upgrades.
+- **Cross-version benchmarking** — quantify quality/cost when you switch models.
+
+→ **Deep dive:** [LLM Evaluation](../mlops/intro_llm_evaluation.md) · [Testing AI Systems](../devops/intro_testing_ai.md)
+
+## 20. Observability & Tracing
+
+You can't debug what you can't see.
+
+- **Tools** — LangSmith, Langfuse, Arize Phoenix, OpenTelemetry (GenAI semantic conventions).
+- **End-to-end traces** — every model call, tool call, and decision as spans.
+- **Logging tool calls** — inputs, outputs, latency, errors.
+- **Debugging failures** — replay a trace to find where the agent went wrong.
+- **Cost & latency** — track tokens/cost/latency per run and per step.
+
+→ **Deep dive:** [LangSmith](./intro_langsmith.md) · [LLMOps](./intro_llmops.md) · [Model Monitoring](../mlops/intro_model_monitoring.md)
+
+## 21. Code Execution Agents
+
+Agents that write and run code.
+
+- **Sandboxing** — E2B, Docker, gVisor, or provider-hosted code execution; never run model code on the host.
+- **Code interpreters** — model writes code → sandbox runs it → results return.
+- **Safety** — resource limits, network egress control, no host filesystem access, timeouts.
+- **Dangerous code** — allowlist/denylist, review gates for destructive ops.
+
+→ **Deep dive:** [Agent Tool Use § Server-Side Tools](./intro_agent_tool_use.md) · [Docker](../devops/intro_docker.md)
+
+## 22. Browser & Computer Use Agents
+
+Agents that operate UIs.
+
+- **Web automation** — Playwright/Puppeteer drive real browsers.
+- **DOM vs screenshot** — parse the DOM (precise, brittle) vs vision-based screenshot interaction (general, costlier).
+- **Computer use** — vision models that take screenshots and emit mouse/keyboard actions.
+- **Edge cases** — CAPTCHAs, dynamic pages, auth, rate limits, flakiness.
+
+→ **Deep dive:** [Testing AI Systems (Playwright/Puppeteer)](../devops/intro_testing_ai.md) · [Multimodal AI](./intro_multimodal_ai.md)
+
+---
+
+# Production & Senior Layer
+
+## 23. Agent Reliability & Failure Modes
+
+Why agents fail — and how to contain it.
+
+| Failure mode | Mitigation |
+|--------------|-----------|
+| Prompt brittleness | Robust prompts, evals, version prompts |
+| Tool failure cascades | Graceful tool errors (`is_error`), retries, fallbacks |
+| Infinite loops | Max-iteration + token budgets; loop detection |
+| Hallucinated tool calls | Strict schemas; validate before executing |
+| Context poisoning | Treat tool/retrieved content as untrusted data |
+
+→ **Deep dive:** [Agentic AI § Failure Modes & Guardrails](./intro_agentic_ai.md) · [Evaluation & Guardrails](../mlops/intro_evaluation_guardrails.md)
+
+## 24. Latency Optimization
+
+Make agents feel fast.
+
+- **Streaming** — show tokens/progress during the run.
+- **Parallel tool calls** — execute independent tools concurrently.
+- **Smaller models for sub-tasks** — route routing/extraction to a fast tier.
+- **Caching** — prompt caching of the stable prefix; cache deterministic tool results.
+- **Speculative execution / prefetching** — start likely-needed work early.
+
+→ **Deep dive:** [Agentic AI § Cost & Latency](./intro_agentic_ai.md) · [LLM Fundamentals § Prompt Caching](./intro_llm_fundamentals.md)
+
+## 25. Cost Management at Scale
+
+Unit economics decide whether the feature survives.
+
+- **Token budgeting** — cap input/output per task.
+- **Model routing** — cheap model by default, escalate to a frontier model only when needed.
+- **Prompt compression & caching** — shrink and reuse the stable prefix (~10× cheaper cache reads).
+- **Cost per task** — monitor it; alert on outliers.
+- **Unit economics** — know the $/task and whether it's sustainable at your usage.
+
+→ **Deep dive:** [LLM Fundamentals § Estimating Cost](./intro_llm_fundamentals.md) · [Multi-Model Orchestration](./intro_multi_model_orchestration.md)
+
+## 26. Security for Agentic Systems
+
+Agents with tools are an attack surface.
+
+- **Prompt injection** — direct (user) and **indirect** (malicious content inside retrieved docs/tool outputs).
+- **Privilege escalation** — agents should have least-privilege tool/credential access.
+- **Sandboxing** — isolate code/tool execution.
+- **Permissions** — what an agent should *never* be able to do (delete prod, move money) without HITL.
+- **Data exfiltration** — guard against an injected instruction leaking secrets via a tool call.
+
+→ **Deep dive:** [LLM Security](./intro_llm_security.md)
+
+## 27. Deployment Patterns
+
+Get the agent off your laptop.
+
+- **Serverless vs long-running** — serverless functions for short tasks; long-running services for stateful/streaming agents.
+- **Queue-based execution** — Celery / SQS / Cloud Tasks for durable, retryable agent jobs.
+- **Webhook-driven** — trigger agents on events.
+- **Containerization** — package the agent + deps in Docker; scale horizontally on Kubernetes.
+
+→ **Deep dive:** [Backend & System Design for AI](../system_design/intro_backend_ai_system_design.md) · [Docker](../devops/intro_docker.md) · [Kubernetes](../devops/intro_kubernetes.md) · [FastAPI](../frameworks/intro_fastapi.md)
+
+## 28. Agentic Architecture Patterns
+
+Knowing which pattern fits which problem separates seniors from juniors.
+
+| Pattern | Use when |
+|---------|----------|
+| **Orchestrator–worker** | A coordinator delegates to specialists |
+| **Pipeline** | Fixed sequential stages |
+| **Blackboard** | Agents share a common workspace/state |
+| **Event-driven** | React to external events |
+| **Hub-and-spoke** | Central router to many tools/agents |
+| **Map-reduce** | Fan out over items, aggregate results |
+
+→ **Deep dive:** [ML System Design Patterns](../system_design/ml_system_design_patterns.md) · [Multi-Agent Systems](./intro_multi_agent_systems.md)
+
+---
+
+# Expert / Frontier Layer
+
+## 29. Fine-tuning for Agentic Behavior
+
+When prompting isn't enough.
+
+- **When fine-tuning beats prompting** — consistent niche behavior, latency/cost wins from a smaller tuned model, hard-to-prompt formats.
+- **SFT on trajectories** — supervised fine-tuning on successful agent runs.
+- **DPO for tool-use preferences** — preference-optimize toward good tool choices.
+- **Datasets from runs** — mine successful trajectories as training data.
+- **LoRA / QLoRA** — parameter-efficient tuning for fast, cheap iteration.
+
+→ **Deep dive:** [Fine-Tuning (LoRA, QLoRA, RLHF/DPO)](../deep_learning/intro_fine_tuning.md) · [Unsloth](../frameworks/intro_unsloth.md)
+
+## 30. Reasoning Models
+
+Models that "think" at inference time.
+
+- **How they work** — trained (often with RL) to produce long internal chains of thought before answering; spend more compute on hard problems.
+- **When to use** — genuinely hard reasoning/planning; not for simple lookups (slower, costlier).
+- **Cost/latency** — reasoning tokens add latency and cost; gate them behind difficulty.
+- **In agent pipelines** — use a reasoning model for the planner/orchestrator, a fast model for routine sub-steps. Anthropic's **adaptive thinking + effort** controls are this idea exposed as parameters.
+
+→ **Deep dive:** [Anthropic & Claude (extended/adaptive thinking)](./intro_anthropic.md) · [LLM Fundamentals](./intro_llm_fundamentals.md)
+
+## 31. Multi-Modal Agents
+
+Beyond text.
+
+- **Vision + text** — reason over images alongside text.
+- **Document understanding** — PDFs, tables, charts, scans.
+- **Audio** — speech-to-text input (and TTS output).
+- **Image generation as a tool** — call a generator from the agent.
+- **Multi-modal memory** — store and retrieve across modalities.
+
+→ **Deep dive:** [Multimodal AI](./intro_multimodal_ai.md) · [Computer Vision](../deep_learning/intro_computer_vision.md)
+
+## 32. Agent Communication Standards
+
+The emerging interoperability layer.
+
+- **MCP** — standard for agent↔tool/resource communication (tool ecosystem).
+- **A2A (Agent-to-Agent)** — Google's protocol for agent↔agent interoperability.
+- **Interoperable agents** — agents from different vendors cooperating via shared protocols.
+- **Registries & discovery** — find and describe available agents/tools.
+- **Why it matters** — avoids N×M bespoke integrations as the ecosystem grows.
+
+→ **Deep dive:** [MCP](./intro_mcp.md)
+
+## 33. Building Agent Platforms
+
+Infrastructure so *other* teams can ship agents.
+
+- **Agent SDKs** — give teams a paved path to define agents.
+- **Multi-tenant isolation** — separate state, secrets, and compute per tenant.
+- **Permissioning** — scoped tool/credential access per agent/tenant.
+- **Marketplaces & registries** — discover and reuse agents/tools.
+- **Audit logs** — every action traceable for compliance and debugging.
+
+→ **Deep dive:** [Backend & System Design for AI](../system_design/intro_backend_ai_system_design.md) · [LLMOps / MLOps Engineering](../mlops/intro_llmops_mlops_engineering.md)
+
+## 34. Self-Improving Agents / Meta-Agents
+
+Agents that improve agents.
+
+- **Prompt self-optimization** — agents that rewrite and test their own prompts against evals.
+- **Automated red-teaming** — agents that attack agents to find failures.
+- **Agents that build agents** — generate, test, and refine other agents.
+- **Reflection loops** — critique-and-revise to improve outputs.
+- **Constitutional AI** — train/steer behavior against a set of principles rather than only human labels.
+
+→ **Deep dive:** [LLM Evaluation](../mlops/intro_llm_evaluation.md) · [Anthropic (Constitutional AI)](./intro_anthropic.md)
+
+---
+
+## What Actually Gets You Hired
+
+Beyond the stack, senior agentic-AI interviews probe judgment. Be ready to answer:
+
+1. **Can you debug a non-deterministic agent failure with incomplete logs?** →
+   Reproduce with fixed seeds where possible, replay traces, isolate the failing
+   step, add targeted logging, and reason about distributions, not single runs.
+2. **Can you design for graceful (not catastrophic) failure?** → Budgets/caps,
+   tool-error handling, fallbacks, HITL on irreversible actions, circuit breakers.
+3. **Do you understand the autonomy ↔ reliability trade-off?** → More autonomy =
+   more capability and more failure surface; add human checkpoints where cost-of-
+   error is high.
+4. **Have you shipped an agent to real users and handled the edge cases?** →
+   Concrete war stories: rate limits, injection attempts, cost spikes, weird inputs.
+5. **Can you say when NOT to use an agent?** → If the task is fully specifiable,
+   a deterministic pipeline or single LLM call is cheaper, faster, and more reliable.
+6. **Do you have opinions on eval *methodology*, not just tools?** → Trajectory vs
+   outcome evals, judge calibration, dataset curation, regression gating.
+7. **Can you estimate cost and latency *before* building?** → Tokens × price per
+   step × expected steps; identify the latency-critical path; plan caching/routing.
+
+---
+
+## Related Guides
+- [Agentic AI](./intro_agentic_ai.md) · [Agent Tool Use](./intro_agent_tool_use.md) · [Multi-Agent Systems](./intro_multi_agent_systems.md)
+- [LLM Fundamentals](./intro_llm_fundamentals.md) · [Prompt Engineering](./intro_prompt_engineering.md) · [RAG](./intro_rag.md)
+- [Project Setup & Engineering](../project_setup/README.md) · [Backend & System Design for AI](../system_design/intro_backend_ai_system_design.md)

--- a/ai_genai/intro_llm_fundamentals.md
+++ b/ai_genai/intro_llm_fundamentals.md
@@ -150,6 +150,116 @@ prompt-experiments/
 
 ---
 
+## LLM Engineering in Practice (2026)
+
+Knowing the theory isn't enough — interviews and real work test whether you can
+*choose a model, budget tokens, control cost, and tune generation*. This section
+is the practical layer.
+
+### Choosing a Model
+
+Pick the smallest model that clears your quality bar, then scale up only where you
+must. A useful mental model across providers:
+
+| Tier | Use for | Example: Claude family (2026) |
+|------|---------|-------------------------------|
+| **Frontier / reasoning** | Hardest reasoning, long-horizon agentic work, deep research | `claude-fable-5` (most capable), `claude-opus-4-8` |
+| **Balanced workhorse** | Most production traffic — strong quality at lower cost/latency | `claude-sonnet-4-6` |
+| **Fast / cheap** | High-volume, latency-sensitive, simple tasks (classification, routing, extraction) | `claude-haiku-4-5` |
+
+> Other providers offer the same tiering (a frontier model, a balanced model, a
+> small fast model). Always pull current model IDs, context windows, and pricing
+> from the provider's own docs — they change often. For Claude specifics see the
+> [Anthropic & Claude guide](./intro_anthropic.md).
+
+**Approximate Claude pricing (per 1M tokens, 2026):**
+
+| Model | Input | Output | Context | Max output |
+|-------|------:|-------:|---------|-----------:|
+| Claude Fable 5 (`claude-fable-5`) | $10 | $50 | 1M | 128K |
+| Claude Opus 4.8 (`claude-opus-4-8`) | $5 | $25 | 1M | 128K |
+| Claude Sonnet 4.6 (`claude-sonnet-4-6`) | $3 | $15 | 1M | 64K |
+| Claude Haiku 4.5 (`claude-haiku-4-5`) | $1 | $5 | 200K | 64K |
+
+### Context Windows & Token Budgeting
+
+- **Context window** = the max tokens (input + output) the model can attend to in
+  one request. Modern frontier models reach **1M tokens**.
+- **Rough heuristic:** ~1 token ≈ 4 characters ≈ 0.75 English words. Code and
+  non-English text tokenize *less* efficiently.
+- **Don't estimate with the wrong tokenizer.** OpenAI's `tiktoken` undercounts
+  Claude tokens by ~15–20%+. Use the provider's own token-counting endpoint.
+- **Budget the whole request:** `prompt + few-shot + retrieved context + reasoning + output ≤ window`.
+  Reserve headroom for the output (`max_tokens`) and for reasoning/thinking tokens.
+
+### Prompt Caching (the biggest cost lever)
+
+If many requests share a large, stable prefix (system prompt, tool definitions,
+few-shot examples, a long document), **cache it**:
+
+- Cache **reads** cost ~10% of normal input price; cache **writes** cost ~1.25×.
+- It's a **prefix match** — any byte change anywhere in the prefix invalidates
+  everything after it. So keep stable content first and put volatile content
+  (the user's varying question, timestamps) *last*.
+- Silent cache-killers: `datetime.now()` or a UUID in the system prompt,
+  non-deterministic JSON key order, a tool set that varies per request.
+
+### Generation / Decoding Parameters
+
+| Parameter | Effect | Typical use |
+|-----------|--------|-------------|
+| `temperature` | Randomness (0 = near-deterministic, higher = more varied) | Low for extraction/code, higher for brainstorming |
+| `top_p` (nucleus) | Sample from the smallest set of tokens covering probability `p` | Alternative to temperature — don't aggressively tune both |
+| `top_k` | Sample from the top-k tokens | Rarely needed |
+| `max_tokens` | Hard cap on output length | Set generously for generation; small for classification |
+| `stop` sequences | Halt generation on a string | Structured/templated output |
+
+> **Note (2026):** the newest reasoning models increasingly drop manual sampling
+> params in favor of **adaptive thinking** + an **effort** control (`low`→`max`).
+> Instead of a fixed "thinking budget," the model decides how much to reason and
+> you set how hard it should try. Steer behavior with prompting, not `temperature=0`.
+
+### Estimating Cost
+
+```text
+cost ≈ (input_tokens  / 1e6) × input_price
+     + (output_tokens / 1e6) × output_price
+# with caching:
+     + (cached_tokens / 1e6) × (≈0.1 × input_price)   # cache reads
+```
+
+Example: a 50K-token cached system prompt + 2K question → 4K answer on Sonnet 4.6,
+warm cache ≈ (50K×0.1 + 2K)/1e6 × $3 + 4K/1e6 × $15 ≈ $0.021 + $0.060 ≈ **$0.08/request**.
+Without caching the input alone would cost 52K/1e6 × $3 ≈ $0.156.
+
+### Reducing Hallucination
+
+- **Ground the model** with retrieval (RAG) and instruct it to answer only from
+  provided context, citing sources.
+- **Constrain the output** with structured outputs / strict tool schemas.
+- **Lower temperature** for factual tasks.
+- **Add an eval + guardrail layer** — LLM-as-judge, schema validation, and refusal
+  handling. See [Evaluation & Guardrails](../mlops/intro_evaluation_guardrails.md).
+
+### Interview Questions
+
+1. **How do you pick a model for a new feature?** → Start with the cheapest tier
+   that meets the quality bar (measured on an eval set), scale up only where needed,
+   and route easy traffic to a small model.
+2. **What's the single biggest lever for LLM cost at scale?** → Prompt caching of a
+   stable prefix, plus right-sizing the model per task.
+3. **Why not use `tiktoken` to count Claude tokens?** → Wrong tokenizer — it
+   undercounts; use the provider's token-counting API.
+4. **`temperature` vs `top_p`?** → Both control randomness; temperature scales the
+   distribution, top_p truncates it to a probability mass. Tune one, not both hard.
+5. **What is a context window and how do you stay within it?** → Max tokens per
+   request; budget prompt + context + output, trim/retrieve selectively, and use
+   compaction/summarization for long sessions.
+6. **How do you reduce hallucinations?** → Ground with RAG + citations, constrain
+   output structure, lower temperature, and add evals/guardrails.
+
+---
+
 ## Related Topics
 
 - [RAG](./intro_rag.md)

--- a/frameworks/intro_python_for_ai.md
+++ b/frameworks/intro_python_for_ai.md
@@ -1,0 +1,284 @@
+# Python for AI Engineering (2026 Edition)
+
+The foundation under every LLM app and agent. Before RAG, tools, or multi-agent
+orchestration, you need fluent, idiomatic, *production* Python. This guide covers
+the slice of Python that AI engineers use daily — and that interviewers expect you
+to write without thinking.
+
+> **Why it's listed first in the roadmap:** agent code is concurrent, schema-driven,
+> API-heavy, and failure-prone. Weak Python here shows up immediately as flaky,
+> slow, unobservable agents.
+
+---
+
+## Table of Contents
+1. [Core Python You Actually Use](#1-core-python-you-actually-use)
+2. [Type Hints](#2-type-hints)
+3. [async / await & Concurrency](#3-async--await--concurrency)
+4. [Pydantic Models](#4-pydantic-models)
+5. [Environment & Dependency Management](#5-environment--dependency-management)
+6. [Working with APIs](#6-working-with-apis)
+7. [Error Handling & Retries](#7-error-handling--retries)
+8. [Logging & Observability](#8-logging--observability)
+9. [Project Hygiene](#9-project-hygiene)
+10. [Interview Questions](#10-interview-questions)
+
+---
+
+## 1. Core Python You Actually Use
+
+| Feature | Why it matters in AI code |
+|---------|---------------------------|
+| **Comprehensions / generators** | Stream large datasets/embeddings without loading everything into memory |
+| **Context managers (`with`)** | Manage clients, files, DB sessions, spans cleanly |
+| **Decorators** | Wrap functions with retries, caching, tracing, timing |
+| **`dataclasses` / `Enum`** | Lightweight typed records and fixed choice sets |
+| **`functools` (`lru_cache`, `partial`)** | Cache deterministic calls; pre-bind config |
+| **`pathlib`** | Safe, cross-platform path handling (and traversal checks) |
+
+```python
+from functools import lru_cache
+
+@lru_cache(maxsize=1024)
+def embed_cached(text: str) -> tuple[float, ...]:
+    """Cache deterministic embeddings so repeated text isn't re-embedded."""
+    return tuple(embed(text))
+```
+
+---
+
+## 2. Type Hints
+
+Type hints make agent code maintainable *and* power schema generation (Pydantic,
+tool definitions) and editor/static checks.
+
+```python
+from typing import Literal, Optional, Any
+
+def call_model(
+    prompt: str,
+    model: str = "claude-sonnet-4-6",
+    temperature: float = 0.2,
+    tools: Optional[list[dict[str, Any]]] = None,
+    role: Literal["system", "user", "assistant"] = "user",
+) -> str:
+    ...
+```
+
+- Prefer built-in generics (`list[str]`, `dict[str, int]`) on modern Python.
+- `Literal` for fixed string choices; `Optional[X]` = `X | None`.
+- Run a static checker (`mypy` / `pyright`) in CI — it catches a class of bugs
+  before they reach a flaky agent run.
+
+---
+
+## 3. async / await & Concurrency
+
+Agents make **many** network calls. Doing them sequentially is the #1 latency sink.
+`asyncio` lets independent calls run concurrently.
+
+```python
+import asyncio
+
+async def fetch_tool(call):
+    return await run_tool_async(call)
+
+async def run_parallel_tools(tool_calls):
+    # Execute independent tool calls concurrently, gather all results
+    return await asyncio.gather(*(fetch_tool(c) for c in tool_calls))
+```
+
+- **When to use async** — I/O-bound work (API/tool/DB calls). Not CPU-bound work
+  (use processes for that).
+- **`asyncio.gather`** — fan out parallel calls; **`asyncio.as_completed`** — handle
+  results as they finish; **`asyncio.Semaphore`** — cap concurrency to respect rate limits.
+- **Don't block the event loop** — never call a synchronous, blocking SDK inside an
+  async handler; use the async client or `run_in_executor`.
+- Most LLM SDKs ship both sync and async clients — match the one to your app.
+
+```python
+sem = asyncio.Semaphore(10)  # respect provider rate limits
+async def guarded_call(req):
+    async with sem:
+        return await client_async.call(req)
+```
+
+---
+
+## 4. Pydantic Models
+
+Pydantic is the backbone of **structured outputs**, **tool schemas**, and **config**.
+It validates and coerces data at the boundary so the rest of your code trusts its types.
+
+```python
+from pydantic import BaseModel, Field
+
+class SearchArgs(BaseModel):
+    query: str = Field(description="Search query")
+    top_k: int = Field(default=5, ge=1, le=50)
+
+class Settings(BaseModel):
+    model: str = "claude-opus-4-8"
+    temperature: float = 0.2
+    max_tokens: int = 4096
+```
+
+- **Tool schemas** — `SearchArgs.model_json_schema()` produces the JSON schema you
+  hand to an LLM's function-calling API.
+- **Structured outputs** — parse model JSON into a validated object; on failure,
+  re-ask with the validation error (see the `instructor` library).
+- **Config** — `pydantic-settings` reads typed config from env vars / `.env`.
+- **v2 essentials** — `model_validate()`, `model_dump()`, `Field(...)`, validators.
+
+→ Deeper: [Pydantic for AI Systems](./intro_pydantic.md) · [Structured Outputs](../ai_genai/intro_structured_outputs.md)
+
+---
+
+## 5. Environment & Dependency Management
+
+| Tool | Use |
+|------|-----|
+| **`venv`** | Built-in isolated environments |
+| **`uv`** | Fast installer + resolver + lockfile (modern default) |
+| **`poetry` / `pip-tools`** | Dependency management + locking |
+| **`.env` + `python-dotenv` / `pydantic-settings`** | Load secrets/config from env |
+
+```python
+# config.py — never hardcode keys
+from pydantic_settings import BaseSettings
+
+class Config(BaseSettings):
+    anthropic_api_key: str
+    vector_db_url: str = "http://localhost:6333"
+
+    class Config:
+        env_file = ".env"
+
+config = Config()  # reads from environment / .env
+```
+
+- **Pin dependencies** with a lockfile for reproducibility.
+- **Never commit `.env`** — commit `.env.example`; load real secrets from env / a
+  secrets manager. See [GitHub Project Setup](../project_setup/intro_github_project_setup.md).
+
+---
+
+## 6. Working with APIs
+
+```python
+import httpx
+
+async def post_json(url: str, payload: dict, timeout: float = 30.0) -> dict:
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        resp = await client.post(url, json=payload)
+        resp.raise_for_status()
+        return resp.json()
+```
+
+- **`httpx`** (async-capable) or `requests` (sync) for raw HTTP; prefer the
+  provider's official SDK when one exists.
+- **Always set timeouts** — a hung request stalls the whole agent.
+- **Streaming** — consume Server-Sent Events incrementally for token-by-token UX.
+- **Pagination** — loop until the cursor/`has_next` is exhausted.
+- **Token counting** — use the provider's counter (not `tiktoken` for Claude).
+
+→ Production HTTP/API patterns: [FastAPI for AI Backends](./intro_fastapi.md)
+
+---
+
+## 7. Error Handling & Retries
+
+Networks fail, providers rate-limit, and models occasionally return junk. Handle it.
+
+```python
+import time, random
+
+def with_retry(fn, *, retries=5, base=1.0, max_delay=30.0):
+    for attempt in range(retries):
+        try:
+            return fn()
+        except RateLimitError:          # 429 — retryable
+            pass
+        except ServerError:             # 5xx — retryable
+            pass
+        except BadRequestError:         # 4xx — do NOT retry
+            raise
+        delay = min(base * 2 ** attempt + random.uniform(0, 1), max_delay)
+        time.sleep(delay)
+    raise RuntimeError("exhausted retries")
+```
+
+- **Catch a chain, most-specific first** — distinguish retryable (429, 5xx, network)
+  from non-retryable (4xx).
+- **Exponential backoff + jitter** — avoid thundering-herd retries. (Most SDKs do
+  this automatically — configure `max_retries`.)
+- **Validate model output** — wrap structured parsing in try/except and retry with
+  the error message so the model self-corrects.
+- **Fail gracefully** — return a useful error to the agent (e.g. tool `is_error`),
+  don't crash the whole run.
+
+---
+
+## 8. Logging & Observability
+
+Agents are non-deterministic — **logs are how you debug them**.
+
+```python
+import logging, json, uuid
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("agent")
+
+def log_event(event: str, **fields):
+    """Structured log line with a correlation id for tracing a run."""
+    log.info(json.dumps({"event": event, **fields}))
+
+run_id = str(uuid.uuid4())
+log_event("tool_call", run_id=run_id, tool="search", args={"query": "..."})
+```
+
+- **Structured (JSON) logs** — machine-parseable; filter by `run_id`, tool, latency.
+- **Correlation IDs** — tag every log/span in one agent run with the same id.
+- **Log the right things** — each model call (model, tokens, cost, latency), each
+  tool call (name, args, result, error), and decisions.
+- **Levels** — `DEBUG` for traces, `INFO` for events, `WARNING`/`ERROR` for failures.
+- **Graduate to tracing** — OpenTelemetry / LangSmith / Langfuse for end-to-end spans.
+
+→ Deeper: [Observability & Tracing](../ai_genai/intro_langsmith.md) · [LLMOps](../ai_genai/intro_llmops.md)
+
+---
+
+## 9. Project Hygiene
+
+- **`src/` layout**, tests, configs separated from code → see
+  [ML/AI Project Folder Structures](../project_setup/intro_project_structure.md).
+- **Lint/format** with `ruff`; **type-check** with `mypy`/`pyright`; **test** with
+  `pytest` — all in CI.
+- **Pre-commit hooks** to catch issues before they hit CI.
+
+---
+
+## 10. Interview Questions
+
+1. **When do you reach for `async` in an AI app?** → I/O-bound concurrency —
+   parallel model/tool/DB calls. Use `asyncio.gather`, cap with a semaphore for
+   rate limits; don't use it for CPU-bound work.
+2. **Why Pydantic in an LLM pipeline?** → Validate/coerce model output and tool
+   args at the boundary, auto-generate JSON schemas, and load typed config.
+3. **How do you handle a 429 vs a 400?** → Retry 429 (and 5xx) with exponential
+   backoff + jitter; never retry 400 — it's a client error, fix the request.
+4. **How do you make a non-deterministic agent debuggable?** → Structured logs with
+   a per-run correlation id, log every model/tool call with tokens/latency, and
+   end-to-end tracing.
+5. **How do you keep secrets out of code?** → `.env` (git-ignored) + a settings
+   loader locally, secrets manager / CI secrets in production; never hardcode.
+6. **Sync vs async SDK client — does it matter?** → Yes — calling a blocking sync
+   client inside an async handler stalls the event loop; use the async client or
+   offload to an executor.
+
+---
+
+### Related Guides
+- [Pydantic](./intro_pydantic.md) · [FastAPI](./intro_fastapi.md)
+- [The Agentic AI Engineer Roadmap](../ai_genai/intro_agentic_ai_engineering_roadmap.md)
+- [Project Setup & Engineering](../project_setup/README.md)

--- a/index.html
+++ b/index.html
@@ -674,6 +674,7 @@ const TRACKS = [
     desc: 'LLM fundamentals, prompt engineering, structured outputs, RAG, vector databases, LLMOps, agentic AI, multi-agent systems, MCP, LangChain/LangGraph/LangSmith, CrewAI, LLM security, and the Anthropic Claude API.',
     color: '#d2a8ff',
     files: [
+      { label: 'Agentic AI Engineer Roadmap', path: 'ai_genai/intro_agentic_ai_engineering_roadmap.md' },
       { label: 'LLM Fundamentals', path: 'ai_genai/intro_llm_fundamentals.md' },
       { label: 'Prompt Engineering', path: 'ai_genai/intro_prompt_engineering.md' },
       { label: 'Structured Outputs', path: 'ai_genai/intro_structured_outputs.md' },
@@ -748,6 +749,7 @@ const TRACKS = [
     color: '#79c0ff',
     files: [
       { label: 'Overview', path: 'frameworks/README.md' },
+      { label: 'Python for AI Engineering', path: 'frameworks/intro_python_for_ai.md' },
       { label: 'PyTorch', path: 'frameworks/intro_pytorch.md' },
       { label: 'LangChain (LCEL & Advanced)', path: 'frameworks/intro_langchain.md' },
       { label: 'HuggingFace', path: 'frameworks/intro_huggingface.md' },

--- a/index.html
+++ b/index.html
@@ -656,13 +656,27 @@ const TRACKS = [
     ]
   },
   {
+    id: 'project_setup',
+    icon: '🚀',
+    title: 'Project Setup & Engineering',
+    desc: 'How to set up a project on GitHub the right way (git, branching, pull requests, CI, GitHub Pages, secrets) and how to structure real ML, deep-learning, LLM, agent, and data-engineering projects.',
+    color: '#3fb950',
+    files: [
+      { label: 'Overview', path: 'project_setup/README.md' },
+      { label: 'GitHub Project Setup Tutorial', path: 'project_setup/intro_github_project_setup.md' },
+      { label: 'ML/AI Project Folder Structures', path: 'project_setup/intro_project_structure.md' },
+    ]
+  },
+  {
     id: 'ai_genai',
     icon: '🤖',
     title: 'AI & GenAI',
-    desc: 'RAG, vector databases, LLMOps, agentic AI, multi-agent systems, n8n, MCP, LangChain, LangGraph, LangSmith, CrewAI, and Anthropic Claude API.',
+    desc: 'LLM fundamentals, prompt engineering, structured outputs, RAG, vector databases, LLMOps, agentic AI, multi-agent systems, MCP, LangChain/LangGraph/LangSmith, CrewAI, LLM security, and the Anthropic Claude API.',
     color: '#d2a8ff',
     files: [
       { label: 'LLM Fundamentals', path: 'ai_genai/intro_llm_fundamentals.md' },
+      { label: 'Prompt Engineering', path: 'ai_genai/intro_prompt_engineering.md' },
+      { label: 'Structured Outputs', path: 'ai_genai/intro_structured_outputs.md' },
       { label: 'Intro to RAG', path: 'ai_genai/intro_rag.md' },
       { label: 'RAG Engineering', path: 'ai_genai/intro_rag_engineering.md' },
       { label: 'Vector Databases', path: 'ai_genai/intro_vector_databases.md' },
@@ -681,6 +695,7 @@ const TRACKS = [
       { label: 'LangSmith', path: 'ai_genai/intro_langsmith.md' },
       { label: 'CrewAI', path: 'ai_genai/intro_crewai.md' },
       { label: 'Anthropic & Claude', path: 'ai_genai/intro_anthropic.md' },
+      { label: 'LLM Security', path: 'ai_genai/intro_llm_security.md' },
     ]
   },
   {
@@ -715,12 +730,14 @@ const TRACKS = [
     id: 'deep_learning',
     icon: '🧠',
     title: 'Deep Learning',
-    desc: 'Transformer architecture, attention mechanisms, BERT, GPT, and modern neural network architectures.',
+    desc: 'Transformer architecture, attention mechanisms, computer vision, fine-tuning, and modern neural network architectures.',
     color: '#ffa657',
     files: [
       { label: 'Overview', path: 'deep_learning/README.md' },
       { label: 'Applied Deep Learning', path: 'deep_learning/intro_applied_deep_learning.md' },
       { label: 'Transformers', path: 'deep_learning/intro_transformers.md' },
+      { label: 'Computer Vision', path: 'deep_learning/intro_computer_vision.md' },
+      { label: 'Fine-Tuning', path: 'deep_learning/intro_fine_tuning.md' },
     ]
   },
   {
@@ -732,6 +749,7 @@ const TRACKS = [
     files: [
       { label: 'Overview', path: 'frameworks/README.md' },
       { label: 'PyTorch', path: 'frameworks/intro_pytorch.md' },
+      { label: 'LangChain (LCEL & Advanced)', path: 'frameworks/intro_langchain.md' },
       { label: 'HuggingFace', path: 'frameworks/intro_huggingface.md' },
       { label: 'Ollama', path: 'frameworks/intro_ollama.md' },
       { label: 'vLLM', path: 'frameworks/intro_vllm.md' },
@@ -757,6 +775,7 @@ const TRACKS = [
       { label: 'Model Monitoring', path: 'mlops/intro_model_monitoring.md' },
       { label: 'LLM Evaluation', path: 'mlops/intro_llm_evaluation.md' },
       { label: 'Evaluation & Guardrails', path: 'mlops/intro_evaluation_guardrails.md' },
+      { label: 'A/B Testing', path: 'mlops/intro_ab_testing.md' },
     ]
   },
   {

--- a/project_setup/README.md
+++ b/project_setup/README.md
@@ -1,0 +1,26 @@
+# Project Setup & Engineering
+
+Foundational engineering practices every ML/AI Engineer is expected to know:
+how to set up a project on GitHub the right way, and how to structure real
+ML, deep-learning, LLM, agent, and data-engineering projects.
+
+These topics are deliberately "boring" — and that's exactly why they show up in
+interviews and on the job. Strong modeling skills with weak engineering hygiene
+is the most common reason good prototypes never ship.
+
+## Guides
+- **[How to Set Up a Project on GitHub](./intro_github_project_setup.md)** —
+  end-to-end tutorial: git config, repos, branching, pull requests, branch
+  protection, CI with GitHub Actions, releases, GitHub Pages, secrets, and
+  authentication.
+- **[ML/AI Project Folder Structures](./intro_project_structure.md)** —
+  recommended directory layouts for classic ML, deep learning, LLM/GenAI apps,
+  AI agents, and data-engineering pipelines, plus a "where does this go?"
+  decision table and anti-patterns.
+
+## How this connects to the rest of the repo
+- CI/CD details → [GitHub Actions](../devops/intro_github_actions.md)
+- Containerization → [Docker](../devops/intro_docker.md)
+- Experiment tracking & registries → [MLflow](../mlops/intro_mlflow.md)
+- Production AI engineering → [LLMOps / MLOps Engineering](../mlops/intro_llmops_mlops_engineering.md)
+- Agent architecture → [Agentic AI](../ai_genai/intro_agentic_ai.md)

--- a/project_setup/intro_github_project_setup.md
+++ b/project_setup/intro_github_project_setup.md
@@ -1,0 +1,448 @@
+# How to Set Up a Project on GitHub — Complete Tutorial (2026 Edition)
+
+A practical, end-to-end walkthrough for taking an ML/AI project from an empty
+folder to a clean, collaborative, CI-backed GitHub repository. This is the guide
+interviewers expect you to *already know* — version control hygiene, branching,
+pull requests, and CI/CD are table stakes for ML Engineer, AI Engineer, and
+MLOps roles.
+
+> **Why this matters in interviews:** "Walk me through how you'd structure and
+> ship a new ML project" is a common system/behavioral question. Being fluent
+> with git, GitHub Actions, and a sane repo layout signals you can ship, not
+> just prototype in notebooks.
+
+---
+
+## Table of Contents
+1. [Prerequisites](#prerequisites)
+2. [Step 1 — Install and Configure Git](#step-1--install-and-configure-git)
+3. [Step 2 — Create the Repository](#step-2--create-the-repository)
+4. [Step 3 — Initialize the Project Locally](#step-3--initialize-the-project-locally)
+5. [Step 4 — The Essential Files](#step-4--the-essential-files)
+6. [Step 5 — Connect Local to Remote](#step-5--connect-local-to-remote)
+7. [Step 6 — Branching Strategy](#step-6--branching-strategy)
+8. [Step 7 — Pull Requests & Code Review](#step-7--pull-requests--code-review)
+9. [Step 8 — Protect the Main Branch](#step-8--protect-the-main-branch)
+10. [Step 9 — Continuous Integration (GitHub Actions)](#step-9--continuous-integration-github-actions)
+11. [Step 10 — Releases, Tags & Versioning](#step-10--releases-tags--versioning)
+12. [Step 11 — GitHub Pages (Project Docs Site)](#step-11--github-pages-project-docs-site)
+13. [Secrets & Security](#secrets--security)
+14. [Authentication: SSH vs HTTPS vs gh CLI](#authentication-ssh-vs-https-vs-gh-cli)
+15. [Common Mistakes](#common-mistakes)
+16. [Interview Questions](#interview-questions)
+
+---
+
+## Prerequisites
+
+| Tool | Why | Check |
+|------|-----|-------|
+| **Git** | Version control | `git --version` |
+| **A GitHub account** | Remote hosting | github.com |
+| **GitHub CLI (`gh`)** *(optional, recommended)* | Create repos/PRs from the terminal | `gh --version` |
+| **An editor** | VS Code, JetBrains, etc. | — |
+
+---
+
+## Step 1 — Install and Configure Git
+
+```bash
+# macOS
+brew install git
+# Debian/Ubuntu
+sudo apt-get install git
+# Windows: download from git-scm.com
+
+# One-time identity setup (shows up in your commits)
+git config --global user.name  "Your Name"
+git config --global user.email "you@example.com"
+
+# Sensible defaults
+git config --global init.defaultBranch main      # default branch name
+git config --global pull.rebase true             # cleaner history on pull
+git config --global core.autocrlf input          # line-ending sanity (mac/linux)
+```
+
+> Verify with `git config --list`.
+
+---
+
+## Step 2 — Create the Repository
+
+### Option A — On github.com (GUI)
+1. Click **New repository**.
+2. Name it (`my-ml-project`), add a one-line description.
+3. Choose **Public** or **Private**.
+4. Tick **Add a README**, **Add .gitignore → Python**, and **Choose a license** (MIT/Apache-2.0 are common).
+5. **Create repository**, then clone:
+
+```bash
+git clone https://github.com/<you>/my-ml-project.git
+cd my-ml-project
+```
+
+### Option B — From the terminal with `gh`
+```bash
+gh repo create my-ml-project --public --clone --gitignore Python --license mit
+cd my-ml-project
+```
+
+### Option C — Push an existing local folder
+See [Step 5](#step-5--connect-local-to-remote).
+
+---
+
+## Step 3 — Initialize the Project Locally
+
+```bash
+mkdir my-ml-project && cd my-ml-project
+git init                      # creates the .git/ directory
+python -m venv .venv          # isolated environment
+source .venv/bin/activate     # Windows: .venv\Scripts\activate
+```
+
+> See the companion guide **[ML/AI Project Folder Structures](./intro_project_structure.md)**
+> for the recommended directory layout to create here.
+
+---
+
+## Step 4 — The Essential Files
+
+Every healthy repo has these. Skipping them is the #1 sign of an unmaintained project.
+
+### `.gitignore`
+Stop committing junk, secrets, and large artifacts. A minimal Python/ML version:
+
+```gitignore
+# Python
+__pycache__/
+*.py[cod]
+.venv/
+venv/
+.env
+.ipynb_checkpoints/
+
+# ML artifacts (use DVC / model registry instead of git)
+*.ckpt
+*.pt
+*.pth
+*.onnx
+data/raw/
+data/processed/
+models/
+mlruns/
+wandb/
+
+# OS / editor
+.DS_Store
+.idea/
+.vscode/
+```
+
+### `README.md`
+The front door. Include: what it does, how to install, how to run, an example,
+and a project structure overview. (See [Step 11](#step-11--github-pages-project-docs-site) to turn docs into a site.)
+
+### `LICENSE`
+No license = "all rights reserved" by default, meaning others legally cannot use
+it. MIT (permissive) and Apache-2.0 (permissive + patent grant) are the usual
+picks for open work.
+
+### `requirements.txt` / `pyproject.toml`
+Pin dependencies so the project is reproducible.
+
+```bash
+pip freeze > requirements.txt          # quick & dirty
+# or, preferred for libraries/apps:
+# define dependencies in pyproject.toml and use uv/poetry/pip-tools to lock
+```
+
+### `.env.example`
+Commit a template of required env vars (**never the real `.env`**):
+
+```bash
+# .env.example  —  copy to .env and fill in
+ANTHROPIC_API_KEY=
+DATABASE_URL=
+```
+
+### `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
+For collaborative/open-source repos — set expectations for contributors.
+
+---
+
+## Step 5 — Connect Local to Remote
+
+```bash
+git add .
+git commit -m "Initial project scaffold"
+
+# Link to the GitHub remote you created in Step 2
+git remote add origin https://github.com/<you>/my-ml-project.git
+
+git branch -M main           # rename current branch to main
+git push -u origin main      # -u sets the upstream so future pushes are just `git push`
+```
+
+> `git remote -v` confirms the remote URL.
+
+---
+
+## Step 6 — Branching Strategy
+
+**Never commit straight to `main`.** Work on a branch, open a PR, merge after review.
+
+### GitHub Flow (simplest — recommended for most ML projects)
+```
+main ──●──────────────●────────────● (always deployable)
+        \            / \           /
+         ●──●──●────●   ●──●──●────●
+        feature/x      fix/y
+```
+
+```bash
+git switch -c feature/add-training-pipeline   # create + switch (modern syntax)
+# ...work, then...
+git add .
+git commit -m "feat: add training pipeline with early stopping"
+git push -u origin feature/add-training-pipeline
+```
+
+### Branch naming conventions
+| Prefix | Use for |
+|--------|---------|
+| `feature/` | New functionality |
+| `fix/` | Bug fixes |
+| `experiment/` | ML experiments (`experiment/lr-sweep`) |
+| `docs/` | Documentation only |
+| `chore/` | Tooling, deps, CI |
+
+### Conventional Commits
+A widely-used commit message format that enables auto-changelogs and semantic versioning:
+
+```
+feat: add SHAP-based feature attribution
+fix: correct off-by-one in sequence padding
+docs: expand README quickstart
+chore: bump torch to 2.4
+refactor: extract dataloader into module
+```
+
+Format: `<type>(<optional scope>): <description>`.
+
+---
+
+## Step 7 — Pull Requests & Code Review
+
+A **Pull Request (PR)** proposes merging your branch into `main` and is where
+review, CI, and discussion happen.
+
+```bash
+# With the gh CLI
+gh pr create --title "Add training pipeline" --body "Implements early stopping and checkpointing."
+
+# Or push and click the link GitHub prints / open a PR in the web UI.
+```
+
+**A good PR:**
+- Is **small and focused** (one logical change — easier to review, faster to merge).
+- Has a clear title + description (what, why, how to test).
+- Links the issue it closes: `Closes #42` in the body auto-closes the issue on merge.
+- Passes CI (tests, lint) before requesting review.
+
+**PR templates** — add `.github/pull_request_template.md` to standardize:
+
+```markdown
+## What
+<!-- What does this PR do? -->
+
+## Why
+<!-- Why is it needed? -->
+
+## How to test
+<!-- Steps / commands -->
+
+## Checklist
+- [ ] Tests added/updated
+- [ ] Docs updated
+- [ ] CI passing
+```
+
+---
+
+## Step 8 — Protect the Main Branch
+
+In **Settings → Branches → Add branch protection rule** for `main`:
+- ✅ Require a pull request before merging
+- ✅ Require approvals (1+)
+- ✅ Require status checks to pass (your CI)
+- ✅ Require branches to be up to date before merging
+- ✅ (Optional) Require signed commits / linear history
+
+This guarantees nothing untested or unreviewed reaches `main`.
+
+---
+
+## Step 9 — Continuous Integration (GitHub Actions)
+
+CI runs automatically on every push/PR. Create `.github/workflows/ci.yml`:
+
+```yaml
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest ruff
+
+      - name: Lint
+        run: ruff check .
+
+      - name: Run tests
+        run: pytest -q
+```
+
+> For a deeper treatment (matrices, caching, Docker builds, deployment), see
+> the **[GitHub Actions guide](../devops/intro_github_actions.md)**.
+
+**Pre-commit hooks** catch issues *before* they hit CI. Add `.pre-commit-config.yaml`:
+
+```yaml
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.0
+    hooks:
+      - id: ruff
+      - id: ruff-format
+```
+
+```bash
+pip install pre-commit && pre-commit install
+```
+
+---
+
+## Step 10 — Releases, Tags & Versioning
+
+Use **Semantic Versioning** (`MAJOR.MINOR.PATCH`):
+- **MAJOR** — breaking changes
+- **MINOR** — new, backward-compatible features
+- **PATCH** — backward-compatible bug fixes
+
+```bash
+git tag -a v1.0.0 -m "First stable release"
+git push origin v1.0.0
+```
+
+Then **Releases → Draft a new release** on GitHub (or `gh release create v1.0.0 --generate-notes`)
+to attach changelogs and artifacts.
+
+---
+
+## Step 11 — GitHub Pages (Project Docs Site)
+
+Turn `README.md`/`docs/` into a hosted website for free.
+
+1. **Settings → Pages**.
+2. **Source**: Deploy from a branch → `main` → `/ (root)` or `/docs`.
+3. Save. Your site appears at `https://<you>.github.io/<repo>/`.
+
+> This very repository is published with GitHub Pages — `index.html` at the root
+> renders the markdown guides into a browsable site. A `.nojekyll` file disables
+> Jekyll processing so files are served as-is.
+
+For richer docs, use **MkDocs** (`mkdocs-material`) or **Sphinx** with a Pages
+deploy workflow.
+
+---
+
+## Secrets & Security
+
+- **Never commit secrets** (API keys, tokens, passwords). Use `.env` (git-ignored)
+  locally and **GitHub Actions Secrets** (`Settings → Secrets and variables → Actions`)
+  in CI: reference as `${{ secrets.ANTHROPIC_API_KEY }}`.
+- **If you leak a secret**, rotate it immediately — git history is permanent.
+  Removing it from the latest commit is not enough; revoke and reissue the key.
+- Enable **Dependabot** (`Settings → Code security`) for automated dependency
+  vulnerability alerts and PRs.
+- Enable **secret scanning** and **push protection** to block accidental commits
+  of credentials.
+
+---
+
+## Authentication: SSH vs HTTPS vs gh CLI
+
+| Method | Setup | Best for |
+|--------|-------|----------|
+| **HTTPS + token** | Generate a Personal Access Token (PAT), use as password | Simple, works everywhere |
+| **SSH keys** | `ssh-keygen` → add public key to GitHub | No password prompts, dev machines |
+| **`gh auth login`** | One command, browser flow | Easiest; manages credentials for you |
+
+```bash
+# SSH key (one-time)
+ssh-keygen -t ed25519 -C "you@example.com"
+cat ~/.ssh/id_ed25519.pub        # paste into GitHub → Settings → SSH keys
+git remote set-url origin git@github.com:<you>/my-ml-project.git
+```
+
+---
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Committing `data/`, `models/`, `.venv/` | Add to `.gitignore`; use DVC / a model registry for large artifacts |
+| Committing secrets | `.env` git-ignored + Actions Secrets; rotate if leaked |
+| One giant PR | Split into small, focused PRs |
+| Working directly on `main` | Use feature branches + branch protection |
+| No README/LICENSE | Add both — they signal a real, usable project |
+| Vague commit messages (`"fixed stuff"`) | Use Conventional Commits |
+| No CI | Add a GitHub Actions workflow (Step 9) |
+
+---
+
+## Interview Questions
+
+1. **Walk me through how you'd set up a new ML project repo.** → Init, venv,
+   `.gitignore`, README/LICENSE, dependency pinning, branch protection, CI.
+2. **`git merge` vs `git rebase`?** → Merge preserves history with a merge commit;
+   rebase replays commits for a linear history. Don't rebase shared/public branches.
+3. **How do you keep large model files / datasets out of git?** → `.gitignore` +
+   DVC / Git LFS / a model registry (MLflow, S3) — git is for code, not binaries.
+4. **What goes in CI for an ML repo?** → Lint, unit tests, data/schema validation,
+   maybe a tiny training smoke test and model-eval gate.
+5. **How do you handle secrets across local dev and CI?** → `.env` (git-ignored)
+   locally, GitHub Actions Secrets in CI, never hardcoded.
+6. **What is a protected branch and why use it?** → A branch that requires PRs,
+   reviews, and passing checks before merge — prevents unreviewed/broken code on `main`.
+7. **Explain trunk-based vs GitHub Flow vs Git Flow.** → Trunk-based: short-lived
+   branches off `main`, frequent integration. GitHub Flow: branch → PR → merge.
+   Git Flow: long-lived `develop`/`release` branches (heavier; less common for ML).
+
+---
+
+### Related Guides
+- [ML/AI Project Folder Structures](./intro_project_structure.md)
+- [GitHub Actions (CI/CD)](../devops/intro_github_actions.md)
+- [Docker](../devops/intro_docker.md) · [MLflow](../mlops/intro_mlflow.md) · [LLMOps / MLOps Engineering](../mlops/intro_llmops_mlops_engineering.md)

--- a/project_setup/intro_project_structure.md
+++ b/project_setup/intro_project_structure.md
@@ -1,0 +1,343 @@
+# ML / AI Project Folder Structures (2026 Edition)
+
+A reference for how to lay out real machine-learning, deep-learning, LLM/agent,
+and data-engineering projects. A clean structure makes a project reproducible,
+testable, and reviewable — and it's something interviewers probe with "how would
+you organize this?"
+
+> **Principle:** separate **code** (versioned in git), **data** (versioned with
+> DVC / object storage), **configuration** (versioned, environment-overridable),
+> and **artifacts** (tracked in a registry). Don't mix them.
+
+---
+
+## Table of Contents
+1. [Universal Building Blocks](#universal-building-blocks)
+2. [Classic ML Project](#classic-ml-project)
+3. [Deep Learning / Training Project](#deep-learning--training-project)
+4. [LLM / GenAI Application](#llm--genai-application)
+5. [AI Agent Project](#ai-agent-project)
+6. [Data Engineering / Pipeline Project](#data-engineering--pipeline-project)
+7. [Python Packaging Layouts: `src/` vs flat](#python-packaging-layouts-src-vs-flat)
+8. [Where Things Go: A Decision Table](#where-things-go-a-decision-table)
+9. [Anti-Patterns](#anti-patterns)
+10. [Interview Questions](#interview-questions)
+
+---
+
+## Universal Building Blocks
+
+Almost every project has these, regardless of type:
+
+```
+my-project/
+├── README.md               # what / why / how
+├── LICENSE
+├── .gitignore
+├── .env.example            # template for secrets (real .env is git-ignored)
+├── pyproject.toml          # deps + tool config (ruff, pytest, build)
+├── requirements.txt        # or a lockfile (uv.lock / poetry.lock)
+├── Makefile                # `make test`, `make train`, `make lint`
+├── .pre-commit-config.yaml # lint/format before commit
+├── .github/
+│   ├── workflows/ci.yml    # CI pipeline
+│   └── pull_request_template.md
+├── src/                    # source code (importable package)
+├── tests/                  # unit + integration tests
+├── configs/                # YAML/Hydra configs (no hardcoded params)
+├── notebooks/              # exploration only — not the source of truth
+├── scripts/                # one-off / CLI entry points
+└── docs/                   # documentation
+```
+
+---
+
+## Classic ML Project
+
+Tabular / scikit-learn style. Heavily inspired by the popular **Cookiecutter Data Science** layout.
+
+```
+ml-project/
+├── data/
+│   ├── raw/            # immutable original data (git-ignored, DVC-tracked)
+│   ├── interim/        # intermediate transformations
+│   ├── processed/      # final feature sets for modeling
+│   └── external/       # third-party / reference data
+├── models/             # serialized models (git-ignored → registry)
+├── notebooks/
+│   └── 01-eda.ipynb    # number-prefixed, ordered
+├── reports/
+│   └── figures/        # generated plots
+├── src/
+│   ├── __init__.py
+│   ├── data/           # data loading & validation
+│   │   ├── make_dataset.py
+│   │   └── validate.py
+│   ├── features/       # feature engineering
+│   │   └── build_features.py
+│   ├── models/         # train / predict
+│   │   ├── train.py
+│   │   └── predict.py
+│   └── visualization/
+│       └── visualize.py
+├── configs/
+│   └── config.yaml
+├── tests/
+└── dvc.yaml            # data/pipeline versioning (optional but recommended)
+```
+
+**Key ideas:** `data/raw` is *immutable* — you never edit it; transformations
+flow `raw → interim → processed`. Notebooks are for exploration; production logic
+lives in `src/` and is imported into notebooks, not copy-pasted.
+
+---
+
+## Deep Learning / Training Project
+
+PyTorch / training-loop style. Adds experiment tracking, checkpoints, and config-driven runs.
+
+```
+dl-project/
+├── src/
+│   ├── data/
+│   │   ├── dataset.py        # Dataset / DataLoader
+│   │   └── transforms.py
+│   ├── models/
+│   │   ├── architecture.py   # nn.Module definitions
+│   │   └── layers.py
+│   ├── training/
+│   │   ├── trainer.py        # train/eval loop
+│   │   ├── losses.py
+│   │   └── callbacks.py      # early stopping, checkpointing
+│   ├── inference/
+│   │   └── predict.py
+│   └── utils/
+│       ├── seed.py           # reproducibility
+│       └── metrics.py
+├── configs/
+│   ├── model/resnet50.yaml
+│   ├── data/imagenet.yaml
+│   └── train.yaml            # composed with Hydra
+├── experiments/              # per-run outputs (git-ignored)
+│   └── 2026-06-23_resnet/
+│       ├── checkpoints/
+│       ├── logs/
+│       └── config.yaml       # snapshot of the exact config used
+├── scripts/
+│   ├── train.py              # python scripts/train.py --config configs/train.yaml
+│   └── evaluate.py
+├── tests/
+└── Dockerfile                # reproducible training env
+```
+
+**Key ideas:** every run snapshots its config so it's reproducible; checkpoints
+and logs go to `experiments/` (tracked by MLflow / Weights & Biases, not git);
+seeds are set centrally for reproducibility.
+
+---
+
+## LLM / GenAI Application
+
+RAG / chat / generation app. Built around prompts, retrieval, and an API surface.
+
+```
+llm-app/
+├── src/
+│   ├── api/
+│   │   ├── main.py           # FastAPI app
+│   │   └── routes/
+│   ├── llm/
+│   │   ├── client.py         # provider client wrapper (Anthropic, etc.)
+│   │   ├── prompts/          # versioned prompt templates
+│   │   │   ├── system.md
+│   │   │   └── rag_answer.md
+│   │   └── models.py         # model IDs / config in ONE place
+│   ├── rag/
+│   │   ├── ingest.py         # chunking + embedding
+│   │   ├── retriever.py      # vector search + reranking
+│   │   └── vectorstore.py
+│   ├── eval/
+│   │   ├── datasets/         # golden Q&A sets
+│   │   ├── run_eval.py       # offline eval harness
+│   │   └── judges.py         # LLM-as-judge / metrics
+│   └── guardrails/
+│       └── filters.py        # input/output validation, PII checks
+├── configs/
+│   └── app.yaml              # model, temperature, top_k, chunk size
+├── tests/
+│   ├── test_retriever.py
+│   └── test_prompts.py       # prompt regression tests
+├── data/
+│   └── knowledge_base/       # source docs for RAG
+├── .env.example              # ANTHROPIC_API_KEY=, VECTOR_DB_URL=
+└── Dockerfile
+```
+
+**Key ideas:**
+- **Prompts are versioned artifacts** — keep them in files (`prompts/`), not inline
+  string literals scattered through code, so you can diff and regression-test them.
+- **Centralize model IDs and parameters** in `models.py`/`config` so a model
+  upgrade is a one-line change. Use current model IDs (e.g. `claude-opus-4-8`,
+  `claude-sonnet-4-6`, `claude-haiku-4-5`) and read keys from env.
+- **An `eval/` harness is not optional** — LLM apps degrade silently; offline evals
+  + LLM-as-judge catch regressions. See
+  [LLM Evaluation](../mlops/intro_llm_evaluation.md) and
+  [Evaluation & Guardrails](../mlops/intro_evaluation_guardrails.md).
+- **Guardrails** separate from business logic — input validation, output schema
+  enforcement, PII filtering.
+
+---
+
+## AI Agent Project
+
+Tool-using / multi-step agent. Separates the agent loop, tools, memory, and orchestration.
+
+```
+agent-project/
+├── src/
+│   ├── agents/
+│   │   ├── base.py            # shared agent scaffolding
+│   │   ├── researcher.py      # a specialized agent / role
+│   │   └── orchestrator.py    # routing / multi-agent coordination
+│   ├── tools/                 # ONE file per tool, with a clear schema
+│   │   ├── search.py
+│   │   ├── code_exec.py
+│   │   └── registry.py        # tool registration
+│   ├── memory/
+│   │   ├── short_term.py      # working context
+│   │   └── long_term.py       # vector / persistent store
+│   ├── prompts/
+│   │   └── system_agent.md
+│   ├── runtime/
+│   │   ├── loop.py            # the agent loop (perceive → plan → act)
+│   │   └── tracing.py         # observability / spans
+│   └── config.py              # model IDs, effort/thinking, max steps
+├── configs/
+│   └── agent.yaml
+├── evals/
+│   ├── tasks/                 # task suite the agent must pass
+│   └── run.py                 # success-rate / trajectory eval
+├── tests/
+│   └── test_tools.py          # tools are unit-testable in isolation
+└── .env.example
+```
+
+**Key ideas:**
+- **Tools are first-class, isolated, and testable.** Each tool = a typed schema +
+  a handler. You should be able to unit-test a tool without invoking the model.
+- **Separate the agent loop from tools and memory** — the loop orchestrates;
+  tools execute; memory persists.
+- **Evaluate agents on task success rate and trajectory**, not just final-token
+  quality. Keep a task suite in `evals/`.
+- **Tracing/observability is built in**, not bolted on — you need to see every
+  tool call to debug. See [Agentic AI](../ai_genai/intro_agentic_ai.md),
+  [Agent Tool Use](../ai_genai/intro_agent_tool_use.md), and
+  [Multi-Agent Systems](../ai_genai/intro_multi_agent_systems.md).
+
+---
+
+## Data Engineering / Pipeline Project
+
+ELT / orchestration style (Airflow + dbt + warehouse).
+
+```
+data-platform/
+├── dags/                     # Airflow DAGs (orchestration)
+│   └── daily_ingest.py
+├── dbt/
+│   ├── models/
+│   │   ├── staging/          # 1:1 with sources, light cleaning
+│   │   ├── intermediate/     # business logic / joins
+│   │   └── marts/            # final, consumer-facing tables
+│   ├── tests/                # dbt data tests (not_null, unique, ...)
+│   └── dbt_project.yml
+├── ingestion/
+│   ├── extractors/           # source connectors
+│   └── loaders/
+├── great_expectations/       # data quality / validation suites
+├── sql/
+├── configs/
+│   └── pipeline.yaml
+├── tests/
+└── docker-compose.yml        # local stack (Airflow + warehouse)
+```
+
+**Key ideas:** the **medallion / staging→intermediate→marts** layering mirrors
+the raw→interim→processed flow in ML. Data quality checks (dbt tests / Great
+Expectations) gate the pipeline. See
+[Data Architecture](../data_engineering/data-architecture.md),
+[Apache Airflow](../data_engineering/intro_apache_airflow.md), and
+[dbt](../data_engineering/intro_dbt.md).
+
+---
+
+## Python Packaging Layouts: `src/` vs flat
+
+| Layout | Looks like | Pros | Cons |
+|--------|-----------|------|------|
+| **`src/` layout** | `src/mypkg/...` | Forces installation to import → catches packaging bugs; no accidental imports from cwd | One extra directory level |
+| **Flat layout** | `mypkg/...` at root | Slightly simpler | Easy to "accidentally work" without installing the package |
+
+**Recommendation:** use the **`src/` layout** for anything shippable. Install in
+editable mode for development:
+
+```bash
+pip install -e .          # reads pyproject.toml, installs your package editable
+```
+
+---
+
+## Where Things Go: A Decision Table
+
+| Thing | Where | Tracked by |
+|-------|-------|-----------|
+| Source code | `src/` | git |
+| Tests | `tests/` | git |
+| Hyperparameters / settings | `configs/*.yaml` | git |
+| Secrets / API keys | `.env` (local), CI secrets | **not git** |
+| Raw data | `data/raw/` | DVC / object storage |
+| Trained models | registry (MLflow/S3) | **not git** |
+| Experiment logs/metrics | MLflow / W&B | tracking server |
+| Prompts | `prompts/*.md` | git (versioned!) |
+| Notebooks | `notebooks/` | git (clear outputs first) |
+| Generated reports/figures | `reports/` | usually **not git** |
+
+---
+
+## Anti-Patterns
+
+| Anti-pattern | Why it hurts | Do instead |
+|--------------|--------------|-----------|
+| All code in one giant notebook | Untestable, unreviewable, not reproducible | Logic in `src/`, import into notebooks |
+| Hardcoded paths / params / model IDs | Breaks on other machines; upgrades are find-and-replace | Centralize in `configs/` + `.env` |
+| Committing data & model binaries to git | Bloats repo, slow clones, history pollution | `.gitignore` + DVC / registry |
+| Secrets in code | Leak risk; permanent in history | `.env` + CI secrets |
+| `utils.py` dumping ground | Becomes an unmaintainable junk drawer | Group by responsibility (`data/`, `features/`, ...) |
+| No `tests/` | Silent breakage, scary refactors | Even a few smoke tests pay off |
+| Prompts as inline strings everywhere | Can't diff, version, or regression-test | `prompts/` files + prompt tests |
+
+---
+
+## Interview Questions
+
+1. **How do you structure an ML repo for reproducibility?** → Separate code/
+   data/config/artifacts; immutable raw data; config-driven runs; pinned deps;
+   seeds set; experiments tracked.
+2. **Where do trained models and datasets belong — and why not git?** → A registry
+   / object storage / DVC; git is optimized for diffable text, not large binaries.
+3. **`src/` layout vs flat — which and why?** → `src/` for shippable packages: it
+   forces proper installation and prevents accidental cwd imports.
+4. **How do you version prompts in an LLM app?** → As files under `prompts/`,
+   in git, with regression tests — treat them like code.
+5. **What makes a tool "well-structured" in an agent project?** → A typed schema +
+   an isolated handler that's unit-testable without the model in the loop.
+6. **How do notebooks fit into a production project?** → Exploration and reporting
+   only; production logic lives in importable modules under `src/`.
+
+---
+
+### Related Guides
+- [How to Set Up a Project on GitHub](./intro_github_project_setup.md)
+- [Agentic AI](../ai_genai/intro_agentic_ai.md) · [RAG Engineering](../ai_genai/intro_rag_engineering.md)
+- [MLflow](../mlops/intro_mlflow.md) · [Feature Stores](../mlops/intro_feature_stores.md)
+- [Data Architecture](../data_engineering/data-architecture.md)


### PR DESCRIPTION
## Summary

Improves the guide without breaking anything: fixes the site so previously-unreachable pages now work, adds the requested **GitHub project setup tutorial + folder-structures** content, and expands the **agents and LLM** material with substantial, valuable subsections. All work is on `claude/brave-curie-utrqwq`.

## 1. Fixed site navigation (`index.html`)
Several real content pages existed in the repo but were **not wired into the site nav**, so they were unreachable from the GitHub Pages app. Now linked:

| Track | Newly reachable pages |
|-------|----------------------|
| AI & GenAI | Prompt Engineering, Structured Outputs, LLM Security |
| Deep Learning | Computer Vision, Fine-Tuning |
| MLOps | A/B Testing |
| Frameworks | LangChain (LCEL & Advanced) |

This brings the interactive site in sync with what the README already documented.

## 2. New section: Project Setup & Engineering (`project_setup/`)
A brand-new learning track (added to both `index.html` and `README.md`):
- **GitHub Project Setup Tutorial** — end-to-end: git config, creating repos, `.gitignore`/README/LICENSE, branching strategy, pull requests & review, branch protection, **GitHub Actions CI**, releases & semver, **GitHub Pages**, secrets handling, and SSH/HTTPS/`gh` auth — with interview Q&A.
- **ML/AI Project Folder Structures** — recommended layouts for classic ML, deep learning, LLM/GenAI apps, AI agents, and data-engineering pipelines, plus a "where does this go?" decision table and anti-patterns.
- Section `README.md` overview.

## 3. Expanded agents & LLM content
- **`intro_agentic_ai.md`** → new *Production Agent Engineering* section: should-you-build-an-agent criteria, tool-surface design, context management (editing/compaction/memory), managed vs self-hosted agents, evaluation, cost/latency levers, failure modes & guardrails, interview Q&A.
- **`intro_agent_tool_use.md`** → *Advanced Tool-Use Patterns*: agentic loop, parallel tool calls, strict schemas, programmatic tool calling, tool search, MCP, server-side tools, and a security checklist.
- **`intro_llm_fundamentals.md`** → *LLM Engineering in Practice (2026)*: model selection tiers (with current Claude model IDs/pricing), token budgeting, prompt caching, decoding params, cost estimation, hallucination reduction, interview Q&A.

## Verification
- ✅ 0 missing/broken paths referenced in `index.html`
- ✅ `index.html` inline JS parses cleanly
- ✅ All new and newly-wired pages return **HTTP 200** when served locally
- ✅ 0 broken relative markdown links in new/edited files
- ✅ No files deleted or overwritten; pre-existing duplicate (`intro_feature_store.md`) and standalone `intro_databricks.html` left untouched to avoid breakage
