### PR TITLE
Add seven new guides, expand the 2026 roadmap, and complete stub guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Please check out [CrackingMachineLearningInterview](https://shafaypro.github.io/
 * [2026 Interview Roadmap](./docs/2026-interview-roadmap.md)
 * [2026 Additional Questions and Answers](./docs/2026-additional-questions.md)
 * [2026 Common Interview Questions (New)](./docs/interview_questions_2026.md)
+* [Behavioral & Project Deep-Dive Guide (New)](./docs/behavioral-interview-guide.md)
 * [AI / GenAI Track](#ai--genai-track)
 * [Classic ML Track](#classic-ml-track)
 * [Deep Learning Track](#deep-learning-track)
@@ -60,6 +61,7 @@ Feel free to share the repository link in your blog, study notes, or interview p
 * [`docs/interview_questions_2026.md`](./docs/interview_questions_2026.md): deep-dive interview Q&A covering agents, RAG, LLM scaling, production AI, and system design. **(New)**
 * [`docs/resources-and-references.md`](./docs/resources-and-references.md): books, references, and additional interview topics.
 * [`docs/study-pattern.md`](./docs/study-pattern.md): recommended preparation topics, difficulty levels, and study structure.
+* [`docs/behavioral-interview-guide.md`](./docs/behavioral-interview-guide.md): STAR stories, the project deep-dive round, ML-specific behavioral questions, and level expectations. **(New)**
 * [`ai_genai/`](./ai_genai): GenAI and LLM engineering topics including n8n, CrewAI, LangGraph, LangSmith, multi-agent systems, and advanced RAG. **(Expanded)**
 * [`classical_ml/`](./classical_ml): classical ML algorithms — time series, clustering, dimensionality reduction, recommender systems, feature engineering.
 * [`mlops/`](./mlops): MLOps topics — MLflow, model serving, feature stores, explainability, data quality, LLM evaluation. **(Expanded)**
@@ -109,8 +111,10 @@ Core topics:
 * [LLM & Generative AI Fundamentals](./ai_genai/intro_llm_fundamentals.md) **(New)**
 * [RAG](./ai_genai/intro_rag.md)
 * [RAG Engineering](./ai_genai/intro_rag_engineering.md) **(New)**
+* [Embeddings (models, chunking, fine-tuning, quantization)](./ai_genai/intro_embeddings.md) **(New)**
 * [Vector Databases](./ai_genai/intro_vector_databases.md)
 * [Vector Databases — Advanced (Pinecone, Weaviate, FAISS, pgvector, Hybrid Search, Reranking)](./ai_genai/intro_vector_databases_advanced.md) **(New)**
+* [LLM Inference Optimization (KV cache, batching, quantization, speculative decoding)](./ai_genai/intro_llm_inference_optimization.md) **(New)**
 * [LLMOps](./ai_genai/intro_llmops.md)
 * [Agentic AI](./ai_genai/intro_agentic_ai.md)
 * [Agent Systems & Tool Use](./ai_genai/intro_agent_tool_use.md) **(New)**
@@ -155,6 +159,7 @@ Core topics:
 * [Deep Learning Overview](./deep_learning/README.md)
 * [Applied Deep Learning Roadmap](./deep_learning/intro_applied_deep_learning.md) **(New)**
 * [Transformers](./deep_learning/intro_transformers.md)
+* [Neural Network Training (optimizers, normalization, regularization, debugging)](./deep_learning/intro_neural_network_training.md) **(New)**
 * [Computer Vision (CNNs, Detection, Segmentation, ViT)](./deep_learning/intro_computer_vision.md) **(New)**
 * [Fine-Tuning (LoRA, QLoRA, PEFT, RLHF/DPO)](./deep_learning/intro_fine_tuning.md) **(New)**
 
@@ -173,6 +178,9 @@ Core topics:
 Use this track for classical ML algorithm interviews, data science roles, and as foundations for ML engineer roles.
 
 Core topics:
+* [Model Evaluation & Metrics (ROC vs PR, calibration, thresholds, CV)](./classical_ml/intro_model_evaluation.md) **(New)**
+* [Ensemble Methods & Gradient Boosting (RF, XGBoost, LightGBM, CatBoost)](./classical_ml/intro_ensemble_methods.md) **(New)**
+* [Statistics & Probability](./classical_ml/intro_statistics_probability.md)
 * [Time Series & Forecasting](./classical_ml/intro_time_series.md)
 * [Clustering Algorithms](./classical_ml/intro_clustering.md)
 * [Dimensionality Reduction](./classical_ml/intro_dimensionality_reduction.md)
@@ -220,6 +228,7 @@ Core topics:
 * [Coding Challenges Overview](./coding_challenges/README.md) **(New)**
 * [Python Coding Challenges](./coding_challenges/python_coding_challenges.md) **(New)**
 * [SQL Coding Challenges](./coding_challenges/sql_coding_challenges.md) **(New)**
+* [ML Coding Challenges — Implement From Scratch](./coding_challenges/ml_coding_challenges.md) **(New)**
 
 ## Frameworks Track
 Use this track for roles requiring hands-on Python API development and AI framework expertise.

--- a/ai_genai/intro_embeddings.md
+++ b/ai_genai/intro_embeddings.md
@@ -1,0 +1,321 @@
+# Embeddings
+
+Embeddings turn text, images, and other data into dense vectors where geometric closeness means semantic similarity. They are the substrate under RAG, semantic search, recommendation, clustering, and deduplication — and the layer where most retrieval quality problems actually live. Interviewers ask about them because getting embeddings wrong silently degrades everything downstream.
+
+---
+
+## Table of Contents
+1. [What an Embedding Is](#what-an-embedding-is)
+2. [From Word2Vec to Modern Text Embeddings](#from-word2vec-to-modern-text-embeddings)
+3. [Similarity Metrics](#similarity-metrics)
+4. [Choosing an Embedding Model](#choosing-an-embedding-model)
+5. [Chunking for Embeddings](#chunking-for-embeddings)
+6. [Fine-Tuning Embeddings](#fine-tuning-embeddings)
+7. [Dimensionality, Quantization, and Cost](#dimensionality-quantization-and-cost)
+8. [Evaluating Embeddings](#evaluating-embeddings)
+9. [Operational Concerns](#operational-concerns)
+10. [Interview Q&A](#interview-qa)
+11. [Common Pitfalls](#common-pitfalls)
+12. [Related Topics](#related-topics)
+
+---
+
+## What an Embedding Is
+
+An embedding is a learned map from an object to a vector in `R^d` such that semantically related objects land close together. "Learned" is the operative word: the geometry comes from a training objective, and the objective determines what "close" means.
+
+```python
+from sentence_transformers import SentenceTransformer
+
+model = SentenceTransformer('BAAI/bge-base-en-v1.5')
+vecs = model.encode(
+    ["How do I reset my password?",
+     "I forgot my login credentials",
+     "What is the refund policy?"],
+    normalize_embeddings=True,     # unit vectors → dot product == cosine similarity
+)
+print(vecs.shape)                  # (3, 768)
+print(vecs[0] @ vecs[1])           # ~0.85 — same intent
+print(vecs[0] @ vecs[2])           # ~0.35 — unrelated
+```
+
+Crucially, embedding similarity is **topical/semantic relatedness**, not entailment or truth. "The drug is effective" and "The drug is not effective" embed very close together — they share nearly all their content words and topic. Any system that needs to distinguish those needs a reranker or an NLI model, not cosine similarity.
+
+---
+
+## From Word2Vec to Modern Text Embeddings
+
+| Era | Approach | Key property | Limitation |
+|---|---|---|---|
+| 2013 | **Word2Vec / GloVe** | One static vector per word; `king - man + woman ≈ queen` | No context — "bank" has one vector |
+| 2018 | **ELMo / BERT (contextual)** | Vector depends on the sentence | Raw BERT `[CLS]` is a poor sentence embedding |
+| 2019 | **Sentence-BERT** | Siamese training with a similarity objective | Needs labeled pairs |
+| 2021+ | **Contrastive at scale** (E5, BGE, GTE) | Trained on massive (query, positive, negatives) triples | Task-prefix conventions vary by model |
+| 2023+ | **LLM-based embedders** (`text-embedding-3`, Voyage, Cohere v3) | Strong multilingual, long inputs, Matryoshka dimensions | API cost, vendor lock-in |
+
+**Why raw BERT embeddings are bad for similarity**: BERT is trained on masked-token prediction, not on making sentence vectors comparable. Mean-pooled BERT vectors occupy a narrow cone in which almost every pair scores above 0.8 cosine — the space is anisotropic, so the numbers carry little discriminative signal. Sentence-BERT fixed this by fine-tuning with a contrastive/triplet objective so distance actually corresponds to semantic difference.
+
+**Contrastive learning**, the modern recipe: pull a query and its relevant document together while pushing apart in-batch negatives, typically with InfoNCE loss:
+
+```
+L = -log( exp(sim(q, d⁺)/τ) / Σ_j exp(sim(q, d_j)/τ) )
+```
+
+Large batches matter here because every other item in the batch acts as a negative — more negatives per step means a sharper decision boundary. **Hard negative mining** (retrieving plausible-but-wrong documents to include as negatives) is the single biggest quality lever when fine-tuning.
+
+---
+
+## Similarity Metrics
+
+| Metric | Formula | Range | Notes |
+|---|---|---|---|
+| **Cosine** | `a·b / (‖a‖‖b‖)` | [-1, 1] | Ignores magnitude; the default for text |
+| **Dot product** | `a·b` | Unbounded | Equals cosine when vectors are normalized; magnitude can encode popularity |
+| **Euclidean (L2)** | `‖a-b‖` | [0, ∞) | Monotonically equivalent to cosine *for normalized vectors* |
+
+For unit-normalized vectors, `‖a-b‖² = 2 - 2·cos(a,b)`, so cosine, dot product, and L2 rank identically. Once vectors are not normalized they diverge, and mismatching the metric to how the model was trained is a real and common bug: if a model was trained with cosine similarity and you query a dot-product index of unnormalized vectors, long documents win purely for being long.
+
+**Rule**: normalize at write time and at query time, then use dot product — it's the fastest and provably equals cosine.
+
+---
+
+## Choosing an Embedding Model
+
+| Consideration | Question to ask |
+|---|---|
+| **Quality** | Where does it sit on MTEB *for my task type* (retrieval ≠ classification ≠ STS)? |
+| **Dimension** | 384 / 768 / 1024 / 3072 — storage and search cost scale linearly |
+| **Max sequence length** | 512 tokens truncates most documents; 8k models change chunking strategy |
+| **Domain** | Legal, medical, code — a domain model often beats a bigger general one |
+| **Multilingual** | Does it share a space across languages, so a French query retrieves English docs? |
+| **Hosting** | API (no ops, per-token cost, data leaves your network) vs self-hosted (GPU, control) |
+| **Asymmetric support** | Does it need query/document prefixes, and are you applying them? |
+
+```python
+# Many modern models are ASYMMETRIC and expect instruction prefixes.
+# Omitting them is a top-3 cause of "our retrieval is mysteriously mediocre".
+query_vec = model.encode("query: how do I reset my password", normalize_embeddings=True)
+doc_vecs  = model.encode(["passage: To reset your password, go to..."], normalize_embeddings=True)
+```
+
+`e5` and `bge` families use prefixes like `query:` / `passage:` (or a BGE query instruction). Check the model card — the same model can lose 5–10 points of recall@10 when prefixes are applied inconsistently between indexing and querying.
+
+**MTEB caveat for interviews**: the leaderboard is useful for a shortlist, not a decision. Models are sometimes tuned on tasks close to the benchmark, and your corpus is not MTEB. Always run a small internal eval set (100–300 real queries with known-relevant documents) before committing — the ranking often changes.
+
+---
+
+## Chunking for Embeddings
+
+A chunk is what gets embedded, retrieved, and shown to the model, so the chunking strategy is a retrieval-quality decision, not preprocessing trivia.
+
+| Strategy | How | Best for |
+|---|---|---|
+| **Fixed-size + overlap** | N tokens, 10–20% overlap | Baseline; simple and surprisingly hard to beat |
+| **Recursive/structural** | Split on `\n\n`, then `\n`, then sentences | Prose documents with structure |
+| **Document-aware** | Split on markdown headers, code functions, table rows | Technical docs, code, structured content |
+| **Semantic** | Split where consecutive-sentence similarity drops | Long unstructured text; costs an extra embedding pass |
+| **Parent-document / small-to-big** | Embed small chunks, return the enclosing parent | Best of both: precise retrieval, complete context |
+| **Contextual retrieval** | Prepend an LLM-generated summary of the document to each chunk | Highest quality; costs one LLM call per chunk at ingest |
+
+```python
+from langchain_text_splitters import RecursiveCharacterTextSplitter
+
+splitter = RecursiveCharacterTextSplitter(
+    chunk_size=800,
+    chunk_overlap=120,          # keeps sentences spanning a boundary retrievable
+    separators=["\n## ", "\n### ", "\n\n", "\n", ". ", " "],  # structure first
+    length_function=len,
+)
+chunks = splitter.split_text(document)
+```
+
+The tradeoff, stated plainly: **small chunks give precise retrieval and poor context; large chunks give rich context and diluted embeddings.** A 2,000-token chunk covering five topics produces an average vector matching none of them well. Small-to-big retrieval resolves the tension — index 300-token chunks for matching, return the 1,500-token parent section for generation.
+
+Always carry metadata on the chunk (source, section, timestamp, permissions, document ID). Metadata filters are usually a bigger accuracy win than any embedding upgrade, and access control depends on them.
+
+---
+
+## Fine-Tuning Embeddings
+
+Worth doing when your domain vocabulary differs from web text (internal product names, legal citations, medical codes, ticket jargon) or when you have real query-document click data.
+
+```python
+from sentence_transformers import SentenceTransformer, InputExample, losses
+from torch.utils.data import DataLoader
+
+model = SentenceTransformer('BAAI/bge-base-en-v1.5')
+
+# (anchor, positive) pairs — MultipleNegativesRankingLoss uses the rest of the batch as negatives
+train_examples = [
+    InputExample(texts=["how to reset password", "Password reset: visit Settings > Security..."]),
+    InputExample(texts=["refund window", "Refunds are accepted within 30 days of purchase..."]),
+]
+loader = DataLoader(train_examples, shuffle=True, batch_size=64)   # larger batch = more negatives
+loss = losses.MultipleNegativesRankingLoss(model)
+
+model.fit(train_objectives=[(loader, loss)], epochs=3, warmup_steps=100)
+```
+
+Where to get pairs without a labeling budget:
+- **Click logs** — (query, clicked document) is a positive; log them from day one.
+- **Synthetic queries** — have an LLM generate 3–5 questions each chunk answers, then train query → chunk.
+- **Existing structure** — FAQ question/answer pairs, ticket title/resolution, doc title/body.
+
+**Hard negatives** are the difference between a small gain and a large one: retrieve the top-20 for each query with the current model, drop the true positive, and use the remaining plausible-but-wrong documents as explicit negatives. Random negatives are too easy — the model learns to separate "unrelated topic", which it already could.
+
+Critical operational point: **fine-tuning changes the vector space, so the entire index must be re-embedded.** Plan for a dual-write or blue/green reindex, and never mix vectors from two model versions in one index — the geometry is incomparable and results will be silently wrong.
+
+---
+
+## Dimensionality, Quantization, and Cost
+
+Storage for `N` vectors of dimension `d` in float32 is `N × d × 4` bytes, plus index overhead.
+
+| Corpus | Dim | float32 | int8 | binary |
+|---|---|---|---|---|
+| 1M chunks | 768 | 2.9 GB | 0.73 GB | 92 MB |
+| 10M chunks | 1536 | 59 GB | 15 GB | 1.8 GB |
+| 100M chunks | 1024 | 390 GB | 98 GB | 12 GB |
+
+**Matryoshka Representation Learning (MRL)** trains a model so that truncating the vector still works: dimensions are ordered by importance, so the first 256 of a 1536-dim OpenAI `text-embedding-3` vector retain most of the quality. This makes a two-stage search practical — retrieve with truncated vectors, rescore the top candidates with full vectors.
+
+```python
+# Adaptive retrieval: cheap wide pass, then exact rescoring
+candidates = index_256d.search(query_256, top_k=200)     # fast, small memory footprint
+final = rescore_with_full_vectors(query_1536, candidates)[:10]
+```
+
+**Quantization** trades a little recall for large savings: int8 (scalar quantization) typically loses ~1–2% recall for 4x compression; binary quantization loses more but is 32x smaller and enables Hamming-distance search, usually paired with a float rescoring pass over the top few hundred candidates.
+
+---
+
+## Evaluating Embeddings
+
+Never evaluate an embedding model by eyeballing similarity scores. Build a small labeled set and measure retrieval directly.
+
+| Metric | What it tells you |
+|---|---|
+| **Recall@k** | Did the right document make the candidate set? The ceiling for everything downstream |
+| **MRR** | How high the first correct result ranks |
+| **NDCG@k** | Ranking quality with graded relevance |
+| **Latency p95** | Whether it's usable |
+
+```python
+def recall_at_k(retriever, eval_set, k=10):
+    """eval_set: list of (query, set_of_relevant_doc_ids)"""
+    hits = 0
+    for query, relevant in eval_set:
+        retrieved = {d.id for d in retriever.search(query, top_k=k)}
+        hits += len(retrieved & relevant) > 0
+    return hits / len(eval_set)
+```
+
+The diagnostic that matters in a RAG debugging interview: **measure retrieval and generation separately.** If recall@10 is 0.55, no amount of prompt engineering will fix the answers — the evidence isn't in the context. Fix retrieval first (hybrid search, reranking, better chunking, metadata filters), then look at generation.
+
+---
+
+## Operational Concerns
+
+- **Versioning.** Store the model name and version alongside every vector. When you upgrade, reindex into a new collection and cut over atomically; mixing spaces produces plausible-looking garbage that no test catches.
+- **Incremental updates.** Deletes and updates must propagate to the index, or the system confidently cites documents that no longer exist. Tie index mutations to the source-of-truth change stream.
+- **Caching.** Embedding the same text repeatedly is pure waste — cache by content hash. Query embeddings for frequent queries are worth caching too.
+- **Batching.** Encoding throughput is dominated by batch size; encode in batches of 32–256 rather than one at a time. This is often a 10x+ ingest speedup.
+- **Access control.** Filter by permission metadata *inside* the vector search, not after — post-filtering can return an empty page when a user lacks access to the top-k, and silently leaks the existence of documents through result counts.
+- **Multi-tenancy.** Either separate collections per tenant (clean isolation, more overhead) or a mandatory `tenant_id` filter (cheaper, one bug away from a data leak). For regulated data, choose separation.
+
+---
+
+## Interview Q&A
+
+#### What is an embedding and why does semantic search need one?
+
+An embedding maps text to a dense vector such that semantically similar text lands nearby in the space. Keyword search matches surface tokens, so "how do I get my money back" fails to retrieve a document titled "Refund Policy" — no shared terms. Embeddings encode meaning, so the two land close and retrieval succeeds.
+
+The tradeoff runs the other way too: embeddings are weak at exact matching — product SKUs, error codes, function names, rare proper nouns — because those carry little distributional meaning. That's why production systems use hybrid retrieval rather than choosing one.
+
+#### Cosine similarity vs dot product vs Euclidean distance — which and why?
+
+For unit-normalized vectors all three produce the same ranking, since `‖a-b‖² = 2 - 2cos(a,b)`. So the practical answer is: normalize at index and query time, then use dot product, which is the cheapest to compute and hardware-accelerated everywhere.
+
+The choice matters when vectors are *not* normalized. Then dot product rewards magnitude, which for text embeddings usually just means document length — an artifact, not relevance. The other case is recommendation systems, where magnitude is sometimes deliberately trained to encode popularity, and dot product is then the correct metric.
+
+#### How do you choose a chunk size?
+
+I'd start from the retrieval unit, not a number: a chunk should be the smallest span that fully answers a typical question. Then I'd measure. Set up 100 real queries with known-good answers, sweep chunk sizes (256/512/1024 tokens) with 10–20% overlap, and compare recall@10.
+
+Structure beats size where it exists — splitting on markdown headers or function boundaries preserves coherence far better than a token count. When both context and precision are needed, I'd use small-to-big: embed small chunks for matching, return the parent section for generation. Empirically 300–800 tokens is the usual sweet spot for prose.
+
+#### Your RAG system gives wrong answers. How do you tell if it's retrieval or generation?
+
+Measure them separately, which requires an eval set of questions with the known-relevant chunk IDs.
+
+First, compute recall@k on the retriever. If the correct chunk isn't being retrieved, generation is irrelevant — fix retrieval: check embedding model and prefix conventions, chunk size, add hybrid search and a reranker, verify metadata filters aren't excluding documents.
+
+If recall is high, feed the *gold* chunks directly to the LLM and see whether the answer is correct. If it is, retrieval ranks poorly (right document, low position — add a reranker). If the answer is still wrong with perfect context, it's a generation problem: prompt structure, context ordering, model capability, or the model ignoring the provided evidence.
+
+#### When would you fine-tune an embedding model instead of using an off-the-shelf one?
+
+When the domain vocabulary is far from web text — internal product codenames, legal citation formats, medical abbreviations, industrial part numbers — a general model treats those tokens as near-noise. Also when I have real query-document relevance data from click logs, which is essentially free supervision.
+
+I'd first exhaust cheaper options: a domain-specific off-the-shelf model, hybrid search with BM25 (which handles the exact-match problem fine-tuning is often chasing), and a cross-encoder reranker, which typically buys more than fine-tuning the bi-encoder for far less effort. If I do fine-tune, hard negative mining is where the gains come from, and I'd budget for a full reindex on every model version.
+
+#### Why can't you mix vectors from two embedding models in one index?
+
+Each model defines its own coordinate system; the axes have no shared meaning. Two vectors of the same dimension from different models are not comparable, so cosine similarity between them is a meaningless number — and it will still return results, ranked by nothing. There's no error, just silently wrong retrieval, which makes it a nasty production bug.
+
+The operational consequence: any embedding model change requires re-embedding the whole corpus. Standard practice is a blue/green reindex into a new collection with the model version recorded in metadata, then an atomic cutover.
+
+#### How do you handle documents longer than the model's context window?
+
+Chunk them, since truncation silently discards content that then can never be retrieved. Beyond that:
+- **Small-to-big**: embed sub-chunks, return the parent for generation.
+- **Hierarchical indexing**: embed a document-level summary as well as chunks, retrieve at the document level first and then within it.
+- **Late chunking** with long-context embedders: run the whole document through the model, then pool per chunk, so each chunk vector carries document-wide context.
+- **Contextual retrieval**: prepend a short LLM-written description of the document to each chunk before embedding — expensive at ingest, and among the largest reported recall gains.
+
+#### What is hybrid search and why does it beat pure vector search?
+
+Hybrid search runs lexical retrieval (BM25) and dense vector retrieval in parallel and fuses the result lists, commonly with Reciprocal Rank Fusion: `score(d) = Σ 1/(k + rank_i(d))`, with `k≈60`.
+
+It wins because the two methods fail in complementary ways. Vectors handle paraphrase and synonymy but blur exact identifiers — error codes, SKUs, function names, rare names. BM25 nails exact terms but returns nothing for a paraphrase with no shared vocabulary. RRF needs no score calibration between the two systems, since it fuses ranks rather than raw scores, which is why it's the common default.
+
+#### How would you reduce embedding storage and search cost for 100M documents?
+
+Layered, from cheapest to most invasive:
+1. **Smaller dimension** — a 768-dim model instead of 3072 is a 4x cut and often loses very little; with a Matryoshka model, truncation is free.
+2. **Scalar (int8) quantization** — 4x smaller for roughly 1–2% recall loss.
+3. **Binary quantization + rescoring** — 32x smaller, Hamming search, then rescore the top few hundred with full vectors to recover most of the accuracy.
+4. **ANN index tuning** — HNSW's `M` and `ef_construction` trade memory and build time for recall; IVF-PQ is far more memory-efficient at large scale.
+5. **Tiered storage** — keep hot partitions in memory and cold ones on disk, partitioned by tenant or recency.
+6. **Deduplicate** — near-duplicate chunks are common in real corpora and waste both storage and result slots.
+
+I'd measure recall@10 at each step against a fixed eval set rather than assuming the published numbers transfer.
+
+---
+
+## Common Pitfalls
+
+| Pitfall | Why it hurts | Fix |
+|---|---|---|
+| Different embedding models for indexing and querying | Vectors are not comparable; results are noise | Pin the model version in metadata; reindex on change |
+| Omitting `query:` / `passage:` prefixes | Asymmetric models lose significant recall | Follow the model card exactly on both paths |
+| Unnormalized vectors with dot-product search | Long documents win on magnitude, not relevance | Normalize at write and query time |
+| Chunks too large | The vector averages several topics and matches none | 300–800 tokens, or small-to-big retrieval |
+| No overlap between chunks | Answers spanning a boundary become unretrievable | 10–20% overlap |
+| Evaluating by eyeballing similarity scores | Scores aren't comparable across models or queries | Recall@k / NDCG on a labeled eval set |
+| Pure vector search for identifiers | Exact codes and names get blurred | Hybrid BM25 + vector with RRF |
+| Post-filtering by permissions | Empty pages and leaked existence of documents | Filter inside the vector search |
+| Forgetting deletes and updates | The system cites documents that no longer exist | Drive index mutations from the source change stream |
+| Assuming the MTEB leader is best for you | Benchmarks aren't your corpus | Run an internal eval set before committing |
+
+---
+
+## Related Topics
+
+- [Intro to RAG](./intro_rag.md)
+- [RAG Engineering](./intro_rag_engineering.md)
+- [Vector Databases](./intro_vector_databases.md)
+- [Vector Databases — Advanced](./intro_vector_databases_advanced.md)
+- [LLM Fundamentals](./intro_llm_fundamentals.md)
+- [Dimensionality Reduction](../classical_ml/intro_dimensionality_reduction.md)
+- [Recommender Systems](../classical_ml/intro_recommender_systems.md)

--- a/ai_genai/intro_llm_inference_optimization.md
+++ b/ai_genai/intro_llm_inference_optimization.md
@@ -1,0 +1,333 @@
+# LLM Inference Optimization
+
+Training an LLM is a one-time cost; serving it is a bill that arrives every month. This is now one of the most-asked areas in AI engineering interviews, because it is where most production LLM budgets and latency SLOs are won or lost. This guide covers the two-phase nature of inference, KV caching, batching, quantization, speculative decoding, and how to reason about latency and cost.
+
+---
+
+## Table of Contents
+1. [The Two Phases of Inference](#the-two-phases-of-inference)
+2. [Latency Metrics That Matter](#latency-metrics-that-matter)
+3. [KV Cache](#kv-cache)
+4. [Batching Strategies](#batching-strategies)
+5. [Attention Kernel Optimizations](#attention-kernel-optimizations)
+6. [Quantization](#quantization)
+7. [Speculative Decoding](#speculative-decoding)
+8. [Serving Frameworks](#serving-frameworks)
+9. [Cost Modeling](#cost-modeling)
+10. [Application-Level Optimizations](#application-level-optimizations)
+11. [Interview Q&A](#interview-qa)
+12. [Common Pitfalls](#common-pitfalls)
+13. [Related Topics](#related-topics)
+
+---
+
+## The Two Phases of Inference
+
+Autoregressive generation has two phases with completely different hardware characteristics. Almost every optimization exists because of this split, and saying so is the fastest way to show you understand the area.
+
+| Phase | What happens | Bottleneck | Parallelism |
+|---|---|---|---|
+| **Prefill** | Process the whole prompt in one forward pass | **Compute-bound** (large matmuls) | All prompt tokens at once |
+| **Decode** | Generate one token at a time | **Memory-bandwidth-bound** | One token per step, per sequence |
+
+During decode, generating a single token requires reading *every model weight* from HBM to compute one small matrix-vector product. For a 13B model in fp16, that's ~26 GB read per token. On an A100 with ~2 TB/s bandwidth, the floor is ~13 ms/token regardless of how fast the GPU's FLOPs are — the arithmetic intensity is terrible.
+
+This single fact explains the field:
+- **Batching helps enormously in decode** — the weights are read once and amortized across all sequences in the batch, so throughput scales nearly linearly until compute finally binds.
+- **Quantization helps decode directly** — half the bytes to read is roughly half the time per token.
+- **Speculative decoding helps** — it verifies several tokens in one weight-read pass.
+- **More FLOPs alone barely helps decode** — which is why raw TFLOPs is a misleading spec for a serving GPU.
+
+---
+
+## Latency Metrics That Matter
+
+| Metric | Definition | Driven by |
+|---|---|---|
+| **TTFT** (time to first token) | Request arrival → first token emitted | Prefill: prompt length, queueing, batch scheduling |
+| **TPOT / ITL** (time per output token) | Steady-state inter-token latency | Decode: memory bandwidth, batch size |
+| **End-to-end latency** | `TTFT + TPOT × output_tokens` | Both |
+| **Throughput** | Tokens/sec across all requests | Batch size, GPU utilization |
+| **Goodput** | Throughput of requests that met their SLO | The number that actually matters |
+
+```
+Total latency = TTFT + (output_tokens - 1) × TPOT
+```
+
+For a chat UI, TTFT dominates perceived responsiveness — stream tokens and users tolerate a slower TPOT as long as text appears quickly. For a batch summarization job, only throughput matters and you should push batch size until TTFT is awful, because nobody is waiting.
+
+**There is a fundamental throughput/latency tradeoff.** Larger batches raise throughput and raise per-request latency. Serving one model to both an interactive chat product and an offline pipeline from the same endpoint is usually a mistake — run separate deployments with different batch configurations.
+
+---
+
+## KV Cache
+
+In attention, each new token attends to all previous tokens. Recomputing keys and values for the whole prefix at every step would be `O(n²)` work per sequence. The KV cache stores them instead, making each decode step `O(n)`.
+
+```
+KV cache bytes = 2 (K and V)
+              × num_layers
+              × num_kv_heads × head_dim
+              × sequence_length
+              × batch_size
+              × bytes_per_element
+```
+
+Worked example — Llama-3-8B (32 layers, 8 KV heads via GQA, head_dim 128) in fp16, 8k context:
+
+```
+2 × 32 × 8 × 128 × 8192 × 2 bytes ≈ 1.07 GB per sequence
+```
+
+At batch size 32 that's **34 GB of KV cache** — larger than the 16 GB of model weights. On long-context workloads the KV cache, not the model, is what limits how many concurrent requests fit on a GPU.
+
+### Reducing KV cache size
+
+| Technique | Mechanism | Saving |
+|---|---|---|
+| **MQA** (multi-query attention) | All query heads share one K/V head | `num_heads`x smaller |
+| **GQA** (grouped-query attention) | Heads share K/V in groups | 4–8x, with better quality than MQA |
+| **MLA** (multi-head latent attention) | Compress K/V to a low-rank latent | Large; used by DeepSeek models |
+| **KV cache quantization** | Store cache in int8/fp8 | 2–4x |
+| **PagedAttention** | Non-contiguous paged allocation | Eliminates fragmentation waste (~2x effective) |
+| **Sliding window / eviction** | Keep only recent + sink tokens | Bounded memory, some quality loss |
+
+**PagedAttention** (vLLM's core contribution) is worth explaining precisely: naive serving preallocates a contiguous buffer sized to the maximum possible sequence length for every request, so a request that generates 100 tokens with a 4096 reservation wastes 97% of its allocation. PagedAttention borrows OS virtual memory: the cache is split into fixed-size blocks allocated on demand and tracked through a block table. Fragmentation drops to near zero, and identical prefixes can share blocks via copy-on-write — which is what makes prefix caching for shared system prompts nearly free.
+
+---
+
+## Batching Strategies
+
+| Strategy | How it works | Problem it has |
+|---|---|---|
+| **No batching** | One request at a time | Wastes almost all GPU throughput |
+| **Static batching** | Wait for N requests, run them together | Whole batch waits for the longest generation |
+| **Dynamic batching** | Batch what has arrived within a time window | Still blocks on the longest sequence |
+| **Continuous / in-flight batching** | Evict finished sequences and admit new ones every step | The standard; 10–20x throughput over static |
+
+Continuous batching matters because generation lengths in a real workload vary by 100x. With static batching, a batch of 32 where one request generates 2,000 tokens and the rest generate 20 keeps 31 slots idle for the whole run. Continuous batching frees each slot the moment its sequence emits EOS and immediately admits a queued request. This is the single largest throughput win available in LLM serving, and it is why vLLM/TGI/TensorRT-LLM exist rather than a plain `model.generate()` loop.
+
+**Chunked prefill** solves a related problem: a long prompt's prefill pass occupies the GPU and stalls every decoding request behind it, spiking their inter-token latency. Splitting prefill into chunks interleaved with decode steps smooths TPOT at a small cost to TTFT.
+
+---
+
+## Attention Kernel Optimizations
+
+**FlashAttention** does not change the math; it changes the memory traffic. Standard attention materializes the `n × n` score matrix in HBM, so memory traffic is `O(n²)`. FlashAttention tiles the computation in SRAM and uses the online-softmax trick to never write the full matrix out, making traffic `O(n²/M)` for SRAM size `M`. The result is 2–4x faster attention and memory that scales linearly in sequence length — which is what made long-context training and inference practical at all.
+
+**PagedAttention** (memory allocation) and **FlashAttention** (kernel efficiency) are complementary and both used in modern servers. A common interview slip is treating them as alternatives.
+
+Other kernel-level levers: CUDA graphs to remove per-step launch overhead (significant when each decode step is only a few milliseconds), fused kernels for the norm+attention+MLP sequence, and tensor parallelism to split a model that doesn't fit on one GPU (with the caveat that it adds an all-reduce on every layer, so it only pays off across fast interconnect like NVLink).
+
+---
+
+## Quantization
+
+Quantization reduces the numerical precision of weights and sometimes activations. Since decode is memory-bandwidth-bound, fewer bytes per weight translates almost directly into faster generation.
+
+| Method | Bits | Type | Quality impact | Notes |
+|---|---|---|---|---|
+| **fp16 / bf16** | 16 | Baseline | — | Standard serving precision |
+| **fp8** | 8 | Post-training | Very small | H100+ native support |
+| **INT8 (SmoothQuant, LLM.int8)** | 8 | Post-training | Small | Handles outlier activation channels |
+| **GPTQ** | 4 | Post-training, calibrated | Small–moderate | Layer-wise second-order error correction |
+| **AWQ** | 4 | Post-training, activation-aware | Small | Protects salient weight channels; fast kernels |
+| **GGUF (llama.cpp)** | 2–8 | Post-training | Varies by level | The CPU/edge standard |
+| **QLoRA (NF4)** | 4 | Training-time | Small | For fine-tuning, not primarily serving |
+
+Rules of thumb worth stating in an interview: 8-bit is essentially free in quality terms and should be the default. 4-bit costs a small but measurable amount of quality — usually acceptable, and worth it when it lets you fit a larger model on the same GPU. Below 4-bit, degradation becomes obvious on reasoning tasks.
+
+**A larger 4-bit model usually beats a smaller fp16 model of the same memory footprint.** A 4-bit 70B model (~35 GB) generally outperforms an fp16 13B (~26 GB) on quality. That framing — quantization as a way to buy a bigger model rather than as a way to shrink a fixed one — is the answer interviewers are looking for.
+
+**Verify quality yourself.** Perplexity barely moves under quantization while task accuracy can drop noticeably, especially on structured output, tool calling, and multi-step reasoning. Run your own eval set on the quantized model before shipping.
+
+---
+
+## Speculative Decoding
+
+A small, fast **draft model** proposes `k` tokens; the large **target model** verifies all `k` in a single forward pass. Accepted tokens are kept, and the first rejection resamples from a corrected distribution.
+
+Why it works: verifying `k` tokens costs almost the same as generating 1, because decode is memory-bandwidth-bound — you read the weights once either way. The speedup is roughly the mean number of accepted tokens per verification step, typically 2–3x on predictable text.
+
+```
+Expected speedup ≈ (1 - α^(k+1)) / ((1 - α)(1 + c·k))
+   α = draft acceptance rate,  c = draft cost relative to target
+```
+
+Key properties:
+- **Output distribution is provably unchanged** with the standard rejection-sampling acceptance rule. This is the crucial point: it is not an approximation and does not trade quality for speed.
+- Acceptance rate matters most. A draft model too weak gets rejected constantly and you pay its cost for nothing; too strong and it's expensive to run.
+- Variants that avoid a separate draft model: **Medusa** (extra prediction heads on the target model), **EAGLE** (feature-level drafting), **n-gram / prompt lookup decoding** (draft by copying from the prompt — remarkably effective for summarization, RAG, and code editing where output copies input heavily).
+
+Speculative decoding improves **latency at low batch sizes**. At high batch sizes the GPU is already compute-saturated and there is no spare capacity to spend on verification, so gains shrink or vanish — a nuance worth mentioning.
+
+---
+
+## Serving Frameworks
+
+| Framework | Strengths | Best for |
+|---|---|---|
+| **vLLM** | PagedAttention, continuous batching, wide model support, OpenAI-compatible API | The default self-hosted choice |
+| **TensorRT-LLM** | Fastest on NVIDIA with compiled kernels; FP8 support | Maximum performance, willing to pay in build complexity |
+| **TGI** (HuggingFace) | Production-ready, good observability, easy HF integration | HF-centric stacks |
+| **SGLang** | RadixAttention prefix caching, strong structured output | Heavy prefix sharing, agents, constrained decoding |
+| **llama.cpp / Ollama** | CPU and Apple Silicon, GGUF quantization | Local development, edge |
+| **Managed APIs** | Zero ops, elastic scale | Variable load, small teams, frontier models |
+
+```python
+# vLLM: offline batch inference
+from vllm import LLM, SamplingParams
+
+llm = LLM(
+    model="meta-llama/Llama-3.1-8B-Instruct",
+    dtype="bfloat16",
+    gpu_memory_utilization=0.90,   # fraction of VRAM for weights + KV cache
+    max_model_len=8192,            # caps KV cache per sequence
+    enable_prefix_caching=True,    # big win for shared system prompts
+    tensor_parallel_size=1,
+)
+params = SamplingParams(temperature=0.7, max_tokens=512)
+outputs = llm.generate(prompts, params)   # continuous batching is automatic
+```
+
+**Self-host vs API** is a cost-and-control question, not an ideology. Self-hosting wins on high, steady volume (a dedicated GPU amortizes well above roughly 20–30% utilization), on data residency requirements, and when you need a custom fine-tune. APIs win on spiky or low volume, on access to frontier models, and on avoiding an on-call rotation for GPU infrastructure. Model the break-even explicitly: an A100 at roughly $1–2/hour is ~$1,000/month, which buys a substantial number of API tokens.
+
+---
+
+## Cost Modeling
+
+```python
+def monthly_cost_api(requests_per_day, in_tokens, out_tokens, price_in, price_out):
+    """price_* in dollars per 1M tokens."""
+    daily = requests_per_day * (in_tokens * price_in + out_tokens * price_out) / 1e6
+    return daily * 30
+
+def monthly_cost_self_hosted(gpu_hourly, num_gpus, utilization=1.0):
+    return gpu_hourly * num_gpus * 24 * 30 / max(utilization, 1e-9)
+
+# Break-even sanity check
+api  = monthly_cost_api(50_000, 2000, 500, price_in=0.25, price_out=1.25)   # ≈ $1,690/mo
+host = monthly_cost_self_hosted(gpu_hourly=1.20, num_gpus=1)                # ≈ $864/mo
+```
+
+Two structural points that matter more than the arithmetic:
+
+1. **Input tokens usually dominate** in RAG and agent systems. A 4,000-token retrieved context with a 200-token answer is 95% input. Optimizing output length is the wrong lever; trimming retrieved context, reranking to fewer chunks, and caching the prompt prefix are the right ones.
+2. **Prompt/prefix caching changes the economics.** Providers charge a fraction (often ~10%) for cached input tokens, and self-hosted prefix caching skips the prefill compute entirely. Putting the stable system prompt and few-shot examples first, with the variable part last, is a design decision worth several times the effort of micro-optimizing wording.
+
+---
+
+## Application-Level Optimizations
+
+Often larger wins than anything at the kernel level, and cheaper to implement:
+
+- **Prompt caching** — order prompts stable-prefix-first so the cache hits. Frequently a 50–90% input cost reduction for agents and RAG.
+- **Semantic caching** — embed the query, and if a near-identical past query exists, return its answer. Excellent for FAQ-style traffic; needs a similarity threshold tuned carefully and an invalidation strategy, or it will confidently serve stale answers.
+- **Model routing** — send easy requests to a small model and hard ones to a large one, with a classifier or heuristic in front. Typically 60–80% cost reduction with minimal quality impact when the routing signal is decent.
+- **Shorter outputs** — instruct the model to be concise, cap `max_tokens`, and return structured data rather than prose. Output tokens are usually 4–5x the price of input.
+- **Streaming** — doesn't change cost or total time, but it slashes *perceived* latency, which is often the actual complaint.
+- **Batch APIs** — providers offer roughly 50% discounts for asynchronous batch jobs with a 24-hour window. Free money for offline workloads.
+- **Stop sequences and early termination** — stop generating the moment the useful content ends.
+- **Context trimming** — retrieve 20, rerank, pass 5. Fewer tokens, and usually *better* answers, since irrelevant context measurably degrades quality.
+
+---
+
+## Interview Q&A
+
+#### Why is LLM inference memory-bandwidth-bound rather than compute-bound?
+
+During decode, one token is generated per step per sequence, so each weight matrix participates in a matrix-*vector* product — a tiny amount of arithmetic per byte loaded. The GPU must stream every model weight from HBM for each step: ~26 GB for a 13B fp16 model. On an A100 at ~2 TB/s that's ~13 ms of pure memory traffic per token, while the arithmetic takes a fraction of that. The GPU sits idle waiting on memory.
+
+Prefill is different: the whole prompt is processed at once, so it's a matrix-matrix product with high arithmetic intensity and it is compute-bound. This is why prefill and decode have different optimizations, why batching multiplies decode throughput almost for free, and why quantization directly speeds up generation.
+
+#### Explain the KV cache and why it can be larger than the model.
+
+Attention needs the keys and values of every previous token. Without a cache, each new token requires recomputing them for the whole prefix — `O(n²)` per sequence. The KV cache stores them, making each step `O(n)`.
+
+Its size is `2 × layers × kv_heads × head_dim × seq_len × batch × dtype_bytes`, which grows linearly in *both* sequence length and batch size while the model weights are fixed. For Llama-3-8B at 8k context, one sequence costs ~1 GB; 32 concurrent sequences cost ~34 GB against 16 GB of fp16 weights. That's why long-context, high-concurrency serving is a KV cache capacity problem, and why GQA, cache quantization, and PagedAttention exist.
+
+#### What is continuous batching and why is it such a large win?
+
+Static batching waits for a fixed group of requests, runs them together, and returns when the *longest* generation finishes. Real workloads have generation lengths varying by 100x, so most slots sit idle for most of the batch's life.
+
+Continuous (in-flight) batching operates at the token level: after every decode step, finished sequences are evicted and queued requests are admitted into the free slots. The GPU stays saturated regardless of length variance. Measured throughput improvements over static batching are typically 10–20x, which is why it's the defining feature of vLLM, TGI, and TensorRT-LLM rather than an optional tuning knob.
+
+#### How does speculative decoding preserve output quality?
+
+The draft model proposes `k` tokens and the target model verifies them in one forward pass, which is nearly free because decode is bandwidth-bound. Each drafted token is accepted with probability `min(1, p_target(x)/p_draft(x))`; on rejection, the token is resampled from the normalized residual distribution `max(0, p_target - p_draft)`.
+
+That acceptance rule is exactly modified rejection sampling, and it makes the resulting sequence distribution **provably identical** to sampling from the target model alone. So it is a pure latency optimization with no quality tradeoff — the tradeoff is compute spent on the draft model and the fact that gains shrink at high batch sizes, where the GPU has no idle capacity to spend on verification.
+
+#### Your chat app has a 4-second time to first token. How do you diagnose and fix it?
+
+TTFT is prefill plus queueing, so I'd first measure which one dominates — instrument queue wait, prefill time, and network separately before changing anything.
+
+If it's **queueing**, the server is saturated: add replicas, enable continuous batching if it isn't on, or use chunked prefill so long prompts stop head-of-line-blocking short ones.
+
+If it's **prefill compute**, the prompt is too long: enable prefix caching so the stable system prompt is computed once, trim retrieved context (rerank 20 down to 5), and drop verbose few-shot examples. Prefill scales with prompt length, so halving the prompt roughly halves TTFT.
+
+If it's **model size**, route easy requests to a smaller model, or use a smaller model with a larger context budget.
+
+Independently of all this, I'd make sure the response streams — a 4-second wall before any text is a much worse experience than 800 ms to first token and a slower stream, at the same total latency.
+
+#### How would you cut LLM serving costs by 70% without hurting quality much?
+
+Layered, measuring at each step:
+1. **Prompt/prefix caching** — often the single biggest win, since input tokens dominate RAG and agent workloads and cached input is roughly 10% of the price.
+2. **Trim context** — retrieve 20, rerank, send 5. Cheaper *and* usually more accurate, since irrelevant context degrades answers.
+3. **Model routing** — a small model handles the 70–80% of easy requests; escalate only when a classifier or confidence signal says so.
+4. **Semantic caching** for repeated or near-repeated queries.
+5. **Cap output length** and prefer structured output over prose; output tokens cost several times input.
+6. **Batch API** (~50% discount) for anything that isn't interactive.
+7. **Quantize to int8/fp8** if self-hosting, or move to 4-bit to fit a larger model on the same GPU.
+
+I'd hold a fixed eval set throughout, because every one of these can quietly degrade quality, and the point is cost reduction *at constant quality*.
+
+#### When should you self-host a model instead of using an API?
+
+Self-host when volume is high and steady enough to amortize a GPU (a dedicated A100 is ~$1,000/month, so the break-even is a real calculation, not a preference), when data cannot leave your network for regulatory reasons, when you need a custom fine-tune or LoRA adapters served at scale, when you need latency guarantees a shared API can't promise, or when you require a specific quantization or sampling behavior.
+
+Use an API when load is spiky (you pay for idle GPUs otherwise), when you need frontier-model quality you can't self-host, when the team has no GPU operations capacity, or during early product development where the model choice is still changing weekly. The honest answer usually starts with an API and moves specific high-volume workloads in-house once the traffic shape is known.
+
+#### What quality risk does 4-bit quantization carry, and how do you validate it?
+
+The risk is uneven: perplexity often moves very little, which makes quantization look safe, while task-level accuracy on reasoning, structured output, and tool calling can drop noticeably. Outlier activation channels are the usual culprit — a few dimensions with very large magnitudes dominate the quantization range, which is exactly what AWQ and SmoothQuant are designed to protect against.
+
+Validation: run the *application's* eval set, not a generic benchmark. Compare fp16 and quantized on task success rate, JSON schema validity, and tool-call correctness; check the tails, not just the mean. If quality holds, 4-bit is usually the right call — and a 4-bit 70B typically beats an fp16 13B at the same memory, which is the real reason to quantize.
+
+#### What's the difference between FlashAttention and PagedAttention?
+
+They solve different problems and are used together. **FlashAttention** is a kernel optimization: it tiles attention computation in SRAM and uses online softmax so the `n × n` attention matrix is never written to HBM, reducing memory traffic and making attention 2–4x faster with memory linear rather than quadratic in sequence length. **PagedAttention** is a memory *allocator*: it stores the KV cache in fixed-size non-contiguous blocks with a block table, eliminating the internal fragmentation of preallocating max-length buffers and enabling copy-on-write sharing of common prefixes.
+
+FlashAttention makes each attention computation faster; PagedAttention lets more sequences fit in memory concurrently. Framing them as alternatives is a common mistake.
+
+---
+
+## Common Pitfalls
+
+| Pitfall | Why it hurts | Fix |
+|---|---|---|
+| Optimizing FLOPs for decode | Decode is bandwidth-bound; FLOPs barely matter | Optimize bytes moved: quantization, GQA, batching |
+| Using `model.generate()` in a loop for serving | No continuous batching, ~10-20x throughput lost | vLLM, TGI, or TensorRT-LLM |
+| Setting `max_model_len` to the model maximum by default | KV cache reservation collapses concurrency | Set it to the real p99 context you serve |
+| Sizing a GPU by model weights only | KV cache often exceeds weights at scale | Budget weights + KV for target concurrency |
+| Variable content at the start of the prompt | Destroys prefix cache hits | Stable system prompt first, variable input last |
+| One deployment for interactive and batch traffic | The batch config ruins interactive latency | Separate deployments with different batch settings |
+| Measuring average latency only | Tail latency is what users and SLOs feel | Track p50/p95/p99 for TTFT and TPOT separately |
+| Trusting perplexity to validate quantization | Task accuracy can drop while perplexity barely moves | Run the application eval set on the quantized model |
+| Stuffing all retrieved context "just in case" | More cost *and* worse answers | Rerank and pass fewer, better chunks |
+| Semantic cache with no invalidation | Confidently serves stale answers | TTL, source-change invalidation, tuned threshold |
+
+---
+
+## Related Topics
+
+- [LLM Fundamentals](./intro_llm_fundamentals.md)
+- [LLMOps](./intro_llmops.md)
+- [Multi-Model Orchestration](./intro_multi_model_orchestration.md)
+- [Embeddings](./intro_embeddings.md)
+- [vLLM](../frameworks/intro_vllm.md)
+- [Ollama](../frameworks/intro_ollama.md)
+- [Transformers](../deep_learning/intro_transformers.md)
+- [Model Serving](../mlops/intro_model_serving.md)
+- [Backend AI System Design](../system_design/intro_backend_ai_system_design.md)

--- a/ai_genai/intro_multi_model_orchestration.md
+++ b/ai_genai/intro_multi_model_orchestration.md
@@ -131,6 +131,63 @@ multi-model-router/
 
 ---
 
+## Interview Q&A
+
+#### How would you design a model router?
+
+Start with the routing signal, because that's the whole design. Options in increasing sophistication: static rules by request type (cheapest, surprisingly effective), a small classifier trained on labeled easy/hard examples, a cascade where the small model attempts first and escalates on low confidence, or an LLM-based router (accurate but adds a call's latency and cost).
+
+The cascade is usually the best starting point because the escalation signal is free — you already have the small model's output and can check confidence, schema validity, or a cheap verifier. Typical result is 60–80% of traffic handled by the small model at a fraction of the cost with minimal quality impact.
+
+The parts to get right: a **fallback** when the chosen provider fails, **per-route evaluation** so you can prove the small model is adequate for its slice, and **logging of which route each request took** so you can audit quality by route rather than in aggregate.
+
+#### How do you build a provider abstraction without lowest-common-denominator APIs?
+
+Define your own interface around what your application needs — messages, tools, structured output, streaming — and adapt each provider to it, rather than adopting one provider's SDK shape as the interface. Keep provider-specific capabilities reachable through an explicit escape hatch instead of hiding them.
+
+The parts that are genuinely hard, and worth naming: tool-calling schemas differ meaningfully between providers; token counting and pricing differ; streaming event shapes differ; and error taxonomies differ (rate limit vs overload vs content filter vs context length). Normalizing errors into your own categories is what makes retry and fallback logic possible at all.
+
+#### What is your fallback strategy when a provider is down?
+
+Layered, with explicit degradation:
+1. **Retry with backoff and jitter** for transient errors — most provider errors are transient, and full jitter prevents a synchronized retry storm.
+2. **Failover to a second provider** with an equivalent model, using the abstraction layer. Requires that prompts work on both, which means testing them on both.
+3. **Degrade to a smaller or local model** if no equivalent is available — a worse answer usually beats an error.
+4. **Serve from cache** for repeated queries.
+5. **Fail gracefully** with a clear message and a queued retry for non-interactive work.
+
+The important design detail is a **circuit breaker**: after N consecutive failures, stop sending traffic to the failing provider for a cooldown period. Without it, every request pays the full timeout before failing over, and your latency collapses even though a healthy provider is available.
+
+#### How do you A/B test two models fairly?
+
+Randomize at the user or session level, not per request — per-request assignment gives one user inconsistent behavior and contaminates the experience being measured. Fix the prompt and retrieval pipeline across arms so only the model varies. Define a primary metric before starting, and guardrails that must not regress: latency, cost per request, error rate, and any safety signal.
+
+For LLM features, add an offline regression suite as a gate before the experiment even starts — an A/B test is expensive and slow, so it should only see candidates that already passed a fixed eval set. And be honest about power: LLM quality effects are often small relative to the variance in user behavior, so decide the minimum detectable effect up front rather than reading noise as a result.
+
+#### How do you compare cost across providers meaningfully?
+
+Not by list price per token. Model **cost per successfully completed task**: a model that's twice the price but needs one attempt instead of three retries is cheaper. Then account for the structure of your traffic — input tokens dominate RAG and agent workloads, so a provider's input price and prompt-caching discount matter far more than its output price. Include the cost of failures, the cost of the router itself if it makes an extra call, and, for self-hosting, the GPU's idle time at your actual utilization.
+
+The metric that survives review is dollars per resolved request at a fixed quality bar, measured on your own traffic.
+
+---
+
+## Common Pitfalls
+
+| Pitfall | Why it hurts | Fix |
+|---|---|---|
+| Routing on request length as a proxy for difficulty | Length and difficulty are only loosely related | Train a classifier, or cascade with a confidence-based escalation |
+| No circuit breaker on a failing provider | Every request pays the full timeout before failover | Trip after N failures, cool down, half-open probe |
+| Retrying without jitter | Synchronized retry storms re-trigger the rate limit | Exponential backoff with full jitter |
+| One prompt assumed portable across providers | Behavior differs; quality silently drops on failover | Test the prompt on every provider in the fallback chain |
+| Comparing list price per token | Ignores retries, caching, and input/output mix | Cost per successfully completed task on real traffic |
+| Per-request A/B assignment | Users see inconsistent behavior; results are contaminated | Randomize by user or session |
+| No per-route quality measurement | Aggregate metrics hide a bad route | Log the route and evaluate each slice separately |
+| Abstraction that hides provider capabilities | You lose structured outputs, caching, or tool features | Keep an explicit escape hatch to provider-native calls |
+| Ignoring normalized error taxonomy | Retry logic can't distinguish rate limit from context overflow | Map provider errors to your own categories |
+
+---
+
 ## Related Topics
 
 - [LLM Fundamentals](./intro_llm_fundamentals.md)

--- a/ai_genai/intro_multimodal_ai.md
+++ b/ai_genai/intro_multimodal_ai.md
@@ -124,6 +124,59 @@ document-understanding/
 
 ---
 
+## Interview Q&A
+
+#### How do vision-language models actually connect the two modalities?
+
+Most follow the same pattern: a vision encoder (usually a ViT) turns the image into a grid of patch embeddings, a projection module maps those into the language model's token embedding space, and the LLM then attends over image tokens and text tokens together in one sequence. The projector is small — a linear layer in LLaVA, a resampler with learned queries in Flamingo and BLIP-2 — and is often the only part trained initially, with both encoders frozen.
+
+CLIP is the other core idea and works differently: it trains an image encoder and a text encoder contrastively so that matching image-text pairs land close in a *shared* space. That gives zero-shot classification and image-text retrieval, but not generation.
+
+#### How many tokens does an image cost, and why does it matter?
+
+A great deal — typically hundreds to a couple of thousand tokens per image depending on resolution and the model's tiling scheme. High-resolution handling usually splits the image into tiles, each costing a full grid of patch tokens, so a single detailed screenshot can cost more than a page of text.
+
+This drives real design decisions: downscale images to the smallest resolution that preserves the detail the task needs, crop to the region of interest rather than sending full pages, cache image analysis results rather than re-sending the same image across turns, and batch questions about one image into a single call instead of one call per question.
+
+#### How would you build a document understanding system?
+
+I'd resist making it a single VLM call. The pipeline that actually works: classify the document type, then route — native-text PDFs go through a text extractor (cheap, exact), scanned pages go through OCR, and pages with complex layout, charts, or handwriting go to a VLM. Extract to a strict schema with structured outputs so downstream code can rely on it, and attach a confidence signal per field.
+
+Then the parts candidates forget: validation rules on the extracted fields (dates parse, totals sum, IDs match a format), a human review queue for low-confidence extractions, and an eval set of real documents with ground-truth fields so you can measure field-level accuracy rather than eyeballing outputs.
+
+#### How do you evaluate a multimodal system?
+
+Per task, and never by looking at a few examples. For extraction, field-level precision and recall against labeled documents. For captioning or VQA, task-specific accuracy on a held-out set plus an LLM judge validated against human labels. For retrieval, recall@k on image-text pairs.
+
+The multimodal-specific failure to test for is **hallucinated visual detail** — the model describing objects, text, or values that aren't in the image. Build an adversarial slice: images that are blurry, blank, rotated, or contain text the model would expect but that isn't there, and measure how often it invents content.
+
+#### When is a multimodal model the wrong choice?
+
+When a deterministic extractor exists: a native-text PDF should be parsed, not described by a VLM that may paraphrase or hallucinate. When the task is high-volume, narrow, and stable — a fine-tuned small classifier is far cheaper than a VLM per image. When exactness is required and errors are costly, unless you add validation and a human review path. And when latency matters, since image prefill is expensive and dominates time-to-first-token.
+
+#### How do you handle audio in a production pipeline?
+
+Decide between cascaded and end-to-end. **Cascaded** (STT → LLM → TTS) is the default: each stage is separately testable, replaceable, and cheap, and you get a text transcript for logging, evaluation, and compliance. **End-to-end speech models** cut latency substantially and preserve tone and interruption handling, which matters for natural conversation, but are harder to debug and evaluate.
+
+For cascaded pipelines the practical issues are streaming (start transcribing before the speaker stops), endpointing (deciding when a turn ended), and domain vocabulary — proper nouns and jargon are where word error rate concentrates, so a custom vocabulary or biasing list is usually the highest-leverage fix.
+
+---
+
+## Common Pitfalls
+
+| Pitfall | Why it hurts | Fix |
+|---|---|---|
+| Sending full-resolution images by default | Token cost and latency explode for no accuracy gain | Downscale to the minimum useful resolution; crop to the region of interest |
+| One API call per question about the same image | Re-pays the image token cost every time | Batch all questions into one call |
+| Using a VLM on native-text PDFs | Slower, costlier, and can paraphrase exact values | Route by document type; extract text directly when possible |
+| Free-text output for extraction tasks | Downstream parsing is brittle | Structured outputs with a strict schema |
+| No validation of extracted fields | Hallucinated values flow silently into systems | Format and consistency checks + low-confidence review queue |
+| Evaluating on clean examples only | Real inputs are blurry, rotated, and partially blank | Adversarial eval slice for visual hallucination |
+| Ignoring image preprocessing consistency | Different resize/orientation between eval and production shifts results | Pin one preprocessing path used by both |
+| Assuming OCR accuracy transfers across domains | Handwriting, tables, and jargon are where WER concentrates | Measure on your own documents; add a vocabulary bias list |
+
+---
+
 ## Related Topics
 
 - [LLM Fundamentals](./intro_llm_fundamentals.md)

--- a/ai_genai/intro_rag_engineering.md
+++ b/ai_genai/intro_rag_engineering.md
@@ -138,6 +138,83 @@ knowledge-base-assistant/
 
 ---
 
+## Interview Q&A
+
+#### Walk me through the components of a production RAG system.
+
+Ingestion (parse, clean, deduplicate, extract metadata), chunking, embedding, indexing into a vector store, then at query time: query understanding or rewriting, retrieval (usually hybrid), reranking, context assembly, generation with citations, and finally logging and evaluation.
+
+The parts candidates usually omit are the ones that decide whether the system works: **reranking**, which fixes the "right document, wrong position" problem cheaply; **metadata filtering**, which is usually a larger accuracy win than a better embedding model and is where access control lives; and the **evaluation loop**, without which you cannot tell whether any change helped.
+
+#### Retrieval returns documents that look relevant but the answer is wrong. What's happening?
+
+Several distinct causes, and they need different fixes:
+- **Topically similar but not answer-bearing.** Embeddings measure relatedness, not whether a passage contains the answer. A reranker (cross-encoder) scores query-document pairs jointly and fixes most of this.
+- **The chunk is truncated.** The answer spans a boundary and each half looks partially relevant. Increase overlap or use small-to-big retrieval.
+- **Stale content.** The index still holds a document that was updated or deleted. Check the ingest pipeline's handling of updates.
+- **Contradictory sources.** Two documents disagree and the model picked one arbitrarily. Add recency and authority metadata, and prefer the newest authoritative source in context assembly.
+- **The model ignored the context.** Verify by feeding the gold chunk directly; if the answer is still wrong, it's a prompt or model problem, not retrieval.
+
+#### How do you evaluate a RAG system?
+
+Separately at each stage, or you cannot localize a regression.
+
+**Retrieval**: recall@k and MRR against a labeled set of questions with known-relevant chunk IDs. Recall@k is the ceiling on everything downstream — if the evidence isn't retrieved, no prompt fixes it.
+
+**Generation given context**: faithfulness (is every claim supported by the retrieved text?), answer relevance, and citation correctness. LLM-as-judge works here if the judge is validated against human labels on a sample.
+
+**End to end**: task success rate on a fixed regression suite, run on every prompt, model, or index change.
+
+**Production**: user feedback signals, escalation rate, and the frequency of "I don't know" responses — a sudden rise usually means retrieval broke, not that the model got more cautious.
+
+#### How do you handle queries the corpus cannot answer?
+
+Explicitly, because the default behavior is confident fabrication. Set a relevance-score floor and return "I don't have information on that" below it. Instruct the model in the prompt to answer only from the provided context and to say when it can't. Require citations, and validate post-hoc that the cited spans exist in the retrieved text. Then monitor the abstention rate as a first-class metric: too low means hallucination, too high means retrieval is failing.
+
+#### Why use hybrid retrieval instead of pure vector search?
+
+Because they fail in complementary ways. Dense retrieval handles paraphrase and synonymy but blurs exact identifiers — error codes, SKUs, function names, rare proper nouns — since those carry little distributional meaning. BM25 nails exact terms but returns nothing when the query shares no vocabulary with the document.
+
+Fusing with Reciprocal Rank Fusion (`score = Σ 1/(k + rank)`, k≈60) avoids having to calibrate BM25 scores against cosine similarities, which live on incomparable scales.
+
+#### Your RAG system is too expensive. Where do you cut?
+
+Input tokens dominate RAG cost, so start there:
+1. **Retrieve more, send less** — retrieve 20 candidates, rerank, pass the top 3–5. Usually cheaper *and* more accurate, since irrelevant context degrades answers.
+2. **Prompt caching** — put the stable system prompt and instructions first so the cached prefix is reused; cached input is typically ~10% of the price.
+3. **Semantic caching** for repeated questions, with a tuned threshold and a real invalidation strategy.
+4. **Model routing** — a small model handles simple lookups, escalating only for synthesis-heavy questions.
+5. **Smaller embedding dimensions or quantized vectors** to cut index cost, verified against recall@k.
+
+#### How do you keep the index fresh?
+
+Drive index mutations from the source of truth's change stream rather than periodic full reindexes: on create/update, re-chunk and upsert; on delete, remove by document ID. Store a content hash per chunk so unchanged chunks are skipped. Keep the ingest timestamp in metadata so retrieval can prefer recent content and so you can audit staleness.
+
+For an embedding model upgrade, the whole corpus must be re-embedded — vectors from two models are not comparable. Standard practice is a blue/green reindex into a new collection with an atomic cutover.
+
+#### When is RAG the wrong tool?
+
+When the knowledge is small and static enough to fit in the prompt — just put it in the context and skip the infrastructure. When the task needs reasoning over the *entire* corpus (aggregate questions like "how many contracts expire this quarter"), which is a database query, not retrieval. When the model needs to internalize a style or format rather than facts — that's fine-tuning. And when the data is highly structured, where SQL or a graph query gives exact answers that top-k similarity cannot.
+
+---
+
+## Common Pitfalls
+
+| Pitfall | Why it hurts | Fix |
+|---|---|---|
+| Chunks too large | The vector averages several topics and matches none well | 300–800 tokens, or small-to-big retrieval |
+| No reranking stage | Right document retrieved but ranked below the cutoff | Cross-encoder rerank of the top 20–50 |
+| Skipping metadata | No filtering, no access control, no recency preference | Attach source, section, timestamp, permissions at ingest |
+| Post-filtering by permissions | Empty result pages and leaked document existence | Filter inside the vector search |
+| Different embedding models for index and query | Vectors are incomparable; results are noise | Pin the model version; reindex on change |
+| No abstention path | The model fabricates when nothing relevant is retrieved | Score floor + explicit "not in context" instruction + citation validation |
+| Evaluating end to end only | You cannot tell retrieval failures from generation failures | Measure recall@k and faithfulness separately |
+| Stuffing all retrieved chunks in "just in case" | Higher cost and measurably worse answers | Rerank and pass fewer, better chunks |
+| Ignoring updates and deletes | The system cites documents that no longer exist | Drive index writes from the source change stream |
+| Variable content at the top of the prompt | Destroys prefix cache hits and inflates cost | Stable prefix first, retrieved context last |
+
+---
+
 ## Related Topics
 
 - [Intro to RAG](./intro_rag.md)

--- a/classical_ml/intro_ensemble_methods.md
+++ b/classical_ml/intro_ensemble_methods.md
@@ -1,0 +1,398 @@
+# Ensemble Methods and Gradient Boosting
+
+Ensemble methods combine many weak learners into one strong predictor. They dominate tabular-data interviews and tabular-data production systems: on structured data, a well-tuned gradient boosted tree still beats a neural network most of the time, and interviewers know it. Expect questions on bagging vs boosting, why Random Forest reduces variance, and how XGBoost differs from LightGBM.
+
+---
+
+## Table of Contents
+1. [Why Ensembles Work](#why-ensembles-work)
+2. [Bagging and Random Forest](#bagging-and-random-forest)
+3. [Boosting](#boosting)
+4. [Gradient Boosting from First Principles](#gradient-boosting-from-first-principles)
+5. [XGBoost vs LightGBM vs CatBoost](#xgboost-vs-lightgbm-vs-catboost)
+6. [Stacking and Blending](#stacking-and-blending)
+7. [Hyperparameter Tuning Guide](#hyperparameter-tuning-guide)
+8. [Feature Importance and Interpretation](#feature-importance-and-interpretation)
+9. [Choosing the Right Ensemble](#choosing-the-right-ensemble)
+10. [Interview Q&A](#interview-qa)
+11. [Common Pitfalls](#common-pitfalls)
+12. [Related Topics](#related-topics)
+
+---
+
+## Why Ensembles Work
+
+Expected prediction error decomposes into three parts:
+
+```
+Error = Bias² + Variance + Irreducible noise
+```
+
+Ensembles attack different terms:
+
+| Family | Base learner | Attacks | How |
+|---|---|---|---|
+| **Bagging** | Low-bias, high-variance (deep trees) | Variance | Average many decorrelated models |
+| **Boosting** | High-bias, low-variance (shallow trees) | Bias | Fit each new model to the previous errors |
+| **Stacking** | Any mix | Both | Learn how to weight heterogeneous models |
+
+The bagging intuition: averaging `n` i.i.d. estimators each with variance `σ²` gives variance `σ²/n`. Real models are not independent, so with pairwise correlation `ρ` the variance becomes:
+
+```
+Var(average) = ρσ² + (1 - ρ) σ² / n
+```
+
+That `ρσ²` floor is why **decorrelating the trees matters more than adding trees**. Random Forest's feature subsampling exists precisely to push `ρ` down.
+
+---
+
+## Bagging and Random Forest
+
+**Bagging** (bootstrap aggregating): train `n` models on `n` bootstrap samples (sampled with replacement, same size as the original), then average (regression) or majority-vote (classification).
+
+**Random Forest** = bagging with decision trees **plus** a second source of randomness: at each split, only a random subset of features (`max_features`) is considered.
+
+```python
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.datasets import make_classification
+from sklearn.model_selection import cross_val_score
+
+X, y = make_classification(n_samples=5000, n_features=30, n_informative=10, random_state=42)
+
+rf = RandomForestClassifier(
+    n_estimators=500,        # more is never worse for accuracy, only for latency
+    max_features='sqrt',     # decorrelates trees; 'sqrt' for classification, ~1/3 for regression
+    min_samples_leaf=1,      # raise to 5-20 on noisy data to regularize
+    n_jobs=-1,
+    oob_score=True,          # free validation estimate from out-of-bag samples
+    random_state=42,
+)
+rf.fit(X, y)
+print(f"OOB accuracy: {rf.oob_score_:.3f}")
+print(f"CV accuracy:  {cross_val_score(rf, X, y, cv=5).mean():.3f}")
+```
+
+### Out-of-bag (OOB) evaluation
+
+Each bootstrap sample leaves out roughly `1/e ≈ 36.8%` of rows. Those out-of-bag rows act as a built-in validation set, so you get an unbiased-ish generalization estimate without a separate holdout. Useful when data is scarce; not a replacement for a proper time-based split on temporal data.
+
+### Extremely Randomized Trees (Extra Trees)
+
+Extra Trees goes further: split thresholds are drawn at random rather than optimized. This increases bias slightly but cuts variance and training time. It often matches Random Forest on noisy data and trains 2–5x faster.
+
+---
+
+## Boosting
+
+Boosting trains models **sequentially**, where each model focuses on what the ensemble got wrong so far.
+
+### AdaBoost
+
+Reweights misclassified samples upward each round and weights each learner by its accuracy.
+
+```
+w_i ← w_i · exp(α_t · 1[y_i ≠ h_t(x_i)])      where α_t = ½ ln((1 - err_t) / err_t)
+```
+
+AdaBoost minimizes exponential loss, which makes it sensitive to label noise and outliers — a permanently mislabeled point gets ever-larger weight.
+
+### Gradient Boosting
+
+Generalizes boosting to any differentiable loss. Instead of reweighting samples, each new tree fits the **negative gradient** of the loss with respect to the current predictions (the "pseudo-residuals").
+
+---
+
+## Gradient Boosting from First Principles
+
+For squared error, the negative gradient *is* the residual, which makes the algorithm easy to see:
+
+```python
+import numpy as np
+from sklearn.tree import DecisionTreeRegressor
+
+class TinyGradientBoosting:
+    """Minimal gradient boosting for squared error — the interview whiteboard version."""
+
+    def __init__(self, n_estimators=100, learning_rate=0.1, max_depth=3):
+        self.n_estimators = n_estimators
+        self.learning_rate = learning_rate
+        self.max_depth = max_depth
+        self.trees = []
+
+    def fit(self, X, y):
+        # Step 0: start from the best constant prediction (mean minimizes squared error)
+        self.init_pred = y.mean()
+        pred = np.full(len(y), self.init_pred)
+
+        for _ in range(self.n_estimators):
+            residual = y - pred                      # negative gradient of ½(y - p)²
+            tree = DecisionTreeRegressor(max_depth=self.max_depth)
+            tree.fit(X, residual)                    # fit the errors, not the labels
+            pred += self.learning_rate * tree.predict(X)   # shrunk step
+            self.trees.append(tree)
+        return self
+
+    def predict(self, X):
+        pred = np.full(len(X), self.init_pred)
+        for tree in self.trees:
+            pred += self.learning_rate * tree.predict(X)
+        return pred
+```
+
+Three ideas carry over to every production implementation:
+
+1. **Shrinkage** (`learning_rate`): small steps generalize better. Lower learning rate needs more trees — they trade off roughly inversely.
+2. **Shallow trees**: depth 3–8. Each tree only needs to capture a bit of remaining signal.
+3. **Additive, sequential**: cannot be parallelized across trees (only within a tree's split search), unlike bagging.
+
+For non-squared losses (log loss, Huber, ranking objectives), the residual is replaced by the loss gradient and the leaf values by a Newton step using the second derivative — that second-order step is XGBoost's core contribution.
+
+---
+
+## XGBoost vs LightGBM vs CatBoost
+
+| Dimension | XGBoost | LightGBM | CatBoost |
+|---|---|---|---|
+| Tree growth | Level-wise (depth-first balanced) | **Leaf-wise** (splits the highest-gain leaf) | Symmetric / oblivious trees |
+| Speed on large data | Fast | **Fastest** (histogram + GOSS + EFB) | Moderate |
+| Small data (< ~10k rows) | Good | Overfits easily leaf-wise | **Best**, ordered boosting resists overfitting |
+| Categorical features | Must encode yourself | Native (`categorical_feature`) | **Native and best-in-class** (ordered target statistics) |
+| Missing values | Learns a default direction per split | Learns a default direction | Handled |
+| Key regularizer | `lambda`, `alpha`, `max_depth` | `num_leaves`, `min_data_in_leaf` | `depth`, `l2_leaf_reg` |
+| Typical pick | Safe default, huge ecosystem | Wide/large datasets, tight training budget | Many categorical columns, small/medium data |
+
+```python
+import xgboost as xgb
+from sklearn.model_selection import train_test_split
+
+X_tr, X_val, y_tr, y_val = train_test_split(X, y, test_size=0.2, stratify=y, random_state=42)
+
+model = xgb.XGBClassifier(
+    n_estimators=2000,          # set high; early stopping picks the real number
+    learning_rate=0.05,
+    max_depth=6,
+    subsample=0.8,              # row sampling per tree — stochastic gradient boosting
+    colsample_bytree=0.8,       # column sampling per tree
+    reg_lambda=1.0,             # L2 on leaf weights
+    min_child_weight=5,         # minimum summed hessian in a leaf — the main anti-overfit knob
+    eval_metric='auc',
+    early_stopping_rounds=50,
+    n_jobs=-1,
+)
+model.fit(X_tr, y_tr, eval_set=[(X_val, y_val)], verbose=False)
+print(f"Best iteration: {model.best_iteration}, best AUC: {model.best_score:.4f}")
+```
+
+### Why leaf-wise growth is both LightGBM's strength and its trap
+
+Level-wise growth splits every node at a depth before going deeper — balanced but wasteful. Leaf-wise always splits whichever leaf reduces loss most, so it reaches lower training loss with the same number of leaves. On small datasets it will happily grow a deep, narrow branch that memorizes 40 rows. Control it with `num_leaves` (keep `num_leaves < 2^max_depth`) and `min_data_in_leaf`, not with `n_estimators`.
+
+---
+
+## Stacking and Blending
+
+Stacking trains a **meta-learner** on the out-of-fold predictions of several base models.
+
+```python
+from sklearn.ensemble import StackingClassifier, RandomForestClassifier
+from sklearn.linear_model import LogisticRegression
+from sklearn.svm import SVC
+
+stack = StackingClassifier(
+    estimators=[
+        ('rf', RandomForestClassifier(n_estimators=300, n_jobs=-1, random_state=42)),
+        ('xgb', xgb.XGBClassifier(n_estimators=300, max_depth=5, learning_rate=0.05)),
+        ('svm', SVC(probability=True)),
+    ],
+    final_estimator=LogisticRegression(),
+    cv=5,             # CRITICAL: base predictions must be out-of-fold
+    passthrough=False,
+    n_jobs=-1,
+)
+stack.fit(X_tr, y_tr)
+```
+
+The `cv=5` is the whole trick. If you train base models and the meta-learner on the same rows, the base models' in-sample predictions are near-perfect, the meta-learner learns to trust them completely, and the stack collapses at inference time. This is the single most common stacking bug.
+
+Stacking wins Kaggle competitions and rarely survives production review: 3–8x the inference cost and 3–8x the models to monitor, for perhaps 0.3% AUC. Bring it up in interviews as a tradeoff you can articulate, not a default.
+
+---
+
+## Hyperparameter Tuning Guide
+
+Tune in this order — later parameters matter less than earlier ones.
+
+| Order | Parameter | Range | Effect |
+|---|---|---|---|
+| 1 | `learning_rate` | 0.01–0.1 | Lower = better generalization, more trees needed |
+| 2 | `n_estimators` | Use early stopping | Let validation decide, don't grid-search it |
+| 3 | `max_depth` / `num_leaves` | 3–10 / 15–255 | Main capacity control |
+| 4 | `min_child_weight` / `min_data_in_leaf` | 1–100 | Prevents leaves fit to a handful of rows |
+| 5 | `subsample`, `colsample_bytree` | 0.6–1.0 | Adds randomness, reduces variance |
+| 6 | `reg_lambda`, `reg_alpha` | 0–10 | L2 / L1 on leaf weights |
+
+```python
+import optuna
+
+def objective(trial):
+    params = {
+        'learning_rate': trial.suggest_float('learning_rate', 0.01, 0.3, log=True),
+        'max_depth': trial.suggest_int('max_depth', 3, 10),
+        'min_child_weight': trial.suggest_int('min_child_weight', 1, 20),
+        'subsample': trial.suggest_float('subsample', 0.6, 1.0),
+        'colsample_bytree': trial.suggest_float('colsample_bytree', 0.6, 1.0),
+        'reg_lambda': trial.suggest_float('reg_lambda', 1e-3, 10.0, log=True),
+        'n_estimators': 2000,
+        'eval_metric': 'auc',
+        'early_stopping_rounds': 50,
+    }
+    m = xgb.XGBClassifier(**params, n_jobs=-1)
+    m.fit(X_tr, y_tr, eval_set=[(X_val, y_val)], verbose=False)
+    return m.best_score
+
+study = optuna.create_study(direction='maximize')
+study.optimize(objective, n_trials=50)
+print(study.best_params)
+```
+
+Bayesian search (Optuna, Hyperopt) beats grid search badly here: the space is 6+ dimensional and most dimensions are unimportant, so random/Bayesian sampling covers the important axes far better per trial.
+
+---
+
+## Feature Importance and Interpretation
+
+Tree "importance" has three common definitions, and they disagree:
+
+| Method | What it measures | Bias |
+|---|---|---|
+| **Gain** (default in XGBoost) | Total loss reduction from splits on the feature | Inflates features used in few high-impact splits |
+| **Split count / weight** | How often the feature is used | Inflates high-cardinality continuous features |
+| **Permutation importance** | Score drop when the feature is shuffled | Honest but misleading with correlated features |
+| **SHAP** | Per-prediction attribution with additive guarantees | Slower; the defensible choice for stakeholders |
+
+```python
+from sklearn.inspection import permutation_importance
+import shap
+
+# Permutation importance — measured on held-out data, which is the point
+perm = permutation_importance(model, X_val, y_val, n_repeats=10, random_state=42, n_jobs=-1)
+
+# SHAP — exact and fast for trees
+explainer = shap.TreeExplainer(model)
+shap_values = explainer.shap_values(X_val)
+shap.summary_plot(shap_values, X_val)
+```
+
+The interview trap: impurity-based importance is computed **on training data** and systematically favors high-cardinality features (a random ID column can rank in your top 5). Always say "permutation or SHAP on a holdout set" when asked how you'd rank features.
+
+---
+
+## Choosing the Right Ensemble
+
+| Situation | Choose | Why |
+|---|---|---|
+| Tabular data, accuracy matters | Gradient boosting (XGBoost/LightGBM) | Consistently strongest on structured data |
+| Many categorical columns | CatBoost | Native ordered target encoding, no leakage |
+| Need a fast, no-tuning baseline | Random Forest | Works well near-default, hard to overfit |
+| Very noisy labels | Random Forest / Extra Trees | Boosting chases noise |
+| Millions of rows, tight training budget | LightGBM | Histogram binning + GOSS |
+| Latency budget under ~1 ms | Single shallow tree / logistic regression | Ensembles cost `n_trees` traversals |
+| Need calibrated probabilities | RF + isotonic, or boosting with log loss | See [Model Evaluation](./intro_model_evaluation.md) |
+| Images, audio, text | Neural networks, not ensembles | Trees cannot exploit spatial/sequential structure |
+
+---
+
+## Interview Q&A
+
+#### What is the difference between bagging and boosting?
+
+Bagging trains models **in parallel** on bootstrap resamples and averages them; it reduces **variance** and needs low-bias, high-variance base learners (deep trees). Boosting trains models **sequentially**, each fitting the errors of the current ensemble; it reduces **bias** and needs high-bias base learners (shallow trees).
+
+The practical consequences: bagging is embarrassingly parallel and nearly impossible to overfit by adding more trees; boosting is sequential and *will* overfit with too many rounds, which is why early stopping is mandatory. Bagging is robust to label noise; boosting amplifies it, because a permanently mislabeled point keeps producing a large residual that later trees keep chasing.
+
+#### Why does Random Forest sample features at each split, not just rows?
+
+Row bootstrapping alone leaves the trees highly correlated: if one feature is strongly predictive, every tree splits on it first and the trees look alike. Since `Var(average) = ρσ² + (1-ρ)σ²/n`, correlated trees leave a variance floor of `ρσ²` that no number of trees removes. Feature subsampling forces different trees to use different features, lowering `ρ` and therefore the floor. It costs a little bias per tree and buys much more variance reduction.
+
+#### Can adding more trees overfit a Random Forest?
+
+Essentially no. Each tree is trained independently, so the average converges as `n → ∞`; more trees reduce the Monte Carlo variance of the average and then plateau. What overfits a Random Forest is **individual tree depth** (`min_samples_leaf=1` on noisy data), not the count. The only cost of more trees is memory and inference latency.
+
+Boosting is the opposite: each additional tree reduces training loss and eventually starts fitting noise, so `n_estimators` is a genuine regularization parameter that must be chosen by early stopping.
+
+#### How does XGBoost differ from vanilla gradient boosting?
+
+Four substantive differences:
+1. **Second-order optimization** — it uses both gradient and Hessian for a Newton step, giving better leaf values and a principled split-gain formula.
+2. **Regularization in the objective** — an explicit penalty on the number of leaves (`gamma`) and the L2 norm of leaf weights (`lambda`), so pruning falls out of the objective rather than being a heuristic.
+3. **Sparsity-aware split finding** — it learns a default direction for missing values instead of requiring imputation.
+4. **Systems engineering** — column blocks for cache-efficient split search, approximate quantile sketch for candidate splits, out-of-core training.
+
+#### Your gradient boosting model has training AUC 0.99 and validation AUC 0.72. What do you do?
+
+Severe overfitting. In order of impact:
+1. Confirm it isn't **leakage** first — a validation AUC that collapsed only after adding a feature usually means that feature encodes the target or the future. Check the top SHAP features for anything computed after the label event.
+2. Lower `learning_rate` and re-fit with early stopping on a proper validation split.
+3. Reduce capacity: shallower `max_depth` / fewer `num_leaves`, raise `min_child_weight`.
+4. Add randomness: `subsample=0.8`, `colsample_bytree=0.8`.
+5. Raise `reg_lambda`.
+6. If the gap persists and the dataset is small, switch to Random Forest or CatBoost, which resist overfitting better at this size.
+
+Also verify the split itself is valid: with temporal data, a random split leaks the future into training and produces exactly this pattern.
+
+#### When would you *not* use gradient boosting?
+
+When inputs have structure trees cannot represent — images, audio, raw text, long sequences — a neural network exploiting that structure wins decisively. When the latency budget is sub-millisecond and you cannot afford hundreds of tree traversals. When you need a genuinely interpretable model for regulatory reasons and SHAP is not accepted. When you must extrapolate beyond the training range (trees output constants outside the observed feature range, so a linear model handles trends better). And when the dataset has a few hundred rows, where a regularized linear model is more honest.
+
+#### How do you handle class imbalance with tree ensembles?
+
+Start with the metric, not the model: accuracy is meaningless at 1% positives; use PR-AUC or recall at a fixed precision. Then in rough order of preference:
+- `scale_pos_weight = n_negative / n_positive` in XGBoost (or `class_weight='balanced'` in sklearn) — reweights the loss, costs nothing.
+- **Threshold tuning** on the validation set — the model's ranking is often fine and only the 0.5 cutoff is wrong. This alone fixes most "the model predicts all zeros" complaints.
+- Resampling (SMOTE, undersampling) — sometimes helps, but SMOTE interpolates in feature space and can create implausible synthetic points with categorical or high-dimensional data. Always resample **inside** the CV fold, never before splitting.
+
+Note that reweighting distorts predicted probabilities; if you need calibrated probabilities, recalibrate afterwards.
+
+#### What is stacking, and what is the main way it goes wrong?
+
+Stacking trains a meta-learner on the predictions of several base models, letting it learn which model to trust in which region of feature space. The dominant failure is **training the meta-learner on in-sample base predictions**: base models nearly memorize their training rows, so the meta-features look far more accurate at fit time than at inference time, and the meta-learner over-trusts them. The fix is out-of-fold predictions — train base models on K-1 folds, predict the held-out fold, assemble those out-of-fold predictions as the meta-training set.
+
+#### Why does a lower learning rate usually generalize better?
+
+Each tree takes a smaller step toward the gradient direction, so the ensemble explores a smoother path and no single tree can dominate the prediction. It's the boosting analogue of small steps in SGD: more, smaller corrections average out the noise in each individual fit. The cost is more rounds — roughly, halving the learning rate doubles the trees needed — so the practical rule is to pick the smallest learning rate your training budget tolerates and let early stopping choose the tree count.
+
+#### How do you make an ensemble fast enough for real-time serving?
+
+Measure first: latency is `n_trees × average_depth` memory-bound traversals. Then, in order:
+- Reduce `n_estimators` — the accuracy/latency curve is steeply diminishing, and 200 trees is often within 0.2% of 2000.
+- Compile the model: Treelite, ONNX Runtime, or `xgboost`'s native inplace prediction give 2–10x over Python-loop scoring.
+- Batch requests so the traversal amortizes across rows.
+- Cache predictions for repeated entities.
+- As a last resort, distill the ensemble into a single shallow tree or a small neural network trained on the ensemble's outputs.
+
+---
+
+## Common Pitfalls
+
+| Pitfall | Why it hurts | Fix |
+|---|---|---|
+| Grid-searching `n_estimators` for boosting | Wastes the search budget on a parameter early stopping solves for free | Set `n_estimators` high, use `early_stopping_rounds` |
+| Trusting default impurity importance | Inflates high-cardinality features; a random ID can rank top-5 | Permutation importance or SHAP on held-out data |
+| Random CV split on temporal data | Leaks the future into training; validation looks great, production fails | Time-based split or `TimeSeriesSplit` |
+| SMOTE before the train/test split | Synthetic points derived from test rows leak across the split | Resample inside the CV fold only |
+| `num_leaves` set to `2^max_depth` in LightGBM | Leaf-wise growth then overfits aggressively | Keep `num_leaves` well below `2^max_depth` |
+| Stacking on in-sample base predictions | Meta-learner over-trusts base models | Out-of-fold predictions (`cv=` in `StackingClassifier`) |
+| Scaling features for trees | Wasted work — trees are invariant to monotonic transforms | Skip scaling; spend the effort on feature construction |
+| Reading `predict_proba` as a real probability | Boosting with reweighting produces distorted scores | Calibrate (Platt/isotonic) and check a reliability curve |
+| Adding trees to fix underfitting from a tiny `max_depth` | Depth-1 stumps cannot express interactions no matter how many | Raise depth to capture interactions, then re-tune |
+
+---
+
+## Related Topics
+
+- [Model Evaluation and Metrics](./intro_model_evaluation.md)
+- [Feature Engineering](./intro_feature_engineering.md)
+- [Statistics and Probability](./intro_statistics_probability.md)
+- [Dimensionality Reduction](./intro_dimensionality_reduction.md)
+- [Model Explainability](../mlops/intro_model_explainability.md)
+- [Classical ML Overview](./README.md)

--- a/classical_ml/intro_model_evaluation.md
+++ b/classical_ml/intro_model_evaluation.md
@@ -1,0 +1,366 @@
+# Model Evaluation and Metrics
+
+Choosing the wrong metric is the most expensive mistake in applied ML, and interviewers probe it constantly. A model with 99% accuracy on a 1% fraud rate has learned nothing. This guide covers classification and regression metrics, ROC vs PR curves, probability calibration, threshold selection, and validation strategies that survive contact with production.
+
+---
+
+## Table of Contents
+1. [The Confusion Matrix](#the-confusion-matrix)
+2. [Classification Metrics](#classification-metrics)
+3. [ROC-AUC vs PR-AUC](#roc-auc-vs-pr-auc)
+4. [Threshold Selection](#threshold-selection)
+5. [Probability Calibration](#probability-calibration)
+6. [Regression Metrics](#regression-metrics)
+7. [Ranking and Recommendation Metrics](#ranking-and-recommendation-metrics)
+8. [Cross-Validation Strategies](#cross-validation-strategies)
+9. [Offline vs Online Metrics](#offline-vs-online-metrics)
+10. [Metric Selection Cheat Sheet](#metric-selection-cheat-sheet)
+11. [Interview Q&A](#interview-qa)
+12. [Common Pitfalls](#common-pitfalls)
+13. [Related Topics](#related-topics)
+
+---
+
+## The Confusion Matrix
+
+Every classification metric is a ratio of these four cells:
+
+```
+                  Predicted
+                Neg      Pos
+Actual  Neg  |  TN   |   FP   |   ← FP = false alarm (Type I error)
+        Pos  |  FN   |   TP   |   ← FN = miss (Type II error)
+```
+
+```python
+from sklearn.metrics import confusion_matrix, classification_report
+
+tn, fp, fn, tp = confusion_matrix(y_true, y_pred).ravel()
+print(classification_report(y_true, y_pred, digits=3))
+```
+
+Ask in every interview: **what does a false positive cost, and what does a false negative cost?** The answer determines the metric, and stating it unprompted is a strong signal.
+
+---
+
+## Classification Metrics
+
+| Metric | Formula | Answers | Use when |
+|---|---|---|---|
+| Accuracy | `(TP+TN)/(TP+TN+FP+FN)` | Overall correctness | Balanced classes, symmetric costs |
+| Precision | `TP/(TP+FP)` | "Of my positive calls, how many were right?" | False positives are costly |
+| Recall (Sensitivity, TPR) | `TP/(TP+FN)` | "Of all real positives, how many did I catch?" | Misses are costly |
+| Specificity (TNR) | `TN/(TN+FP)` | "Of all real negatives, how many did I clear?" | Screening, ROC's x-axis |
+| F1 | `2PR/(P+R)` | Harmonic mean of P and R | Need one number, imbalanced data |
+| Fβ | `(1+β²)PR/(β²P+R)` | Weighted P/R tradeoff | β=2 favors recall, β=0.5 favors precision |
+| Balanced accuracy | `(TPR+TNR)/2` | Accuracy corrected for imbalance | Imbalanced, both classes matter |
+| MCC | correlation of predictions and labels | Single balanced score in [-1, 1] | Imbalanced, want one honest number |
+| Log loss | `-Σ[y log p + (1-y) log(1-p)]` | Probability quality | You need calibrated probabilities |
+| Brier score | `mean((p - y)²)` | Squared probability error | Calibration + sharpness together |
+
+**Why the harmonic mean in F1?** It punishes imbalance between P and R. A model with P=1.0 and R=0.01 has arithmetic mean 0.505 but F1 = 0.0198 — the harmonic mean refuses to reward a model that gets one number by destroying the other.
+
+**Macro vs micro vs weighted averaging** (multiclass):
+- **Macro**: unweighted mean over classes — every class counts equally, so rare classes matter. Use when rare classes are important.
+- **Micro**: pool all TP/FP/FN, then compute — equals accuracy in single-label multiclass. Dominated by frequent classes.
+- **Weighted**: mean weighted by class support — a compromise, but hides rare-class failure.
+
+---
+
+## ROC-AUC vs PR-AUC
+
+Both summarize a ranking across all thresholds, but they answer different questions.
+
+**ROC** plots TPR vs FPR. **ROC-AUC** = probability that a random positive is ranked above a random negative. It is **invariant to class balance** — which is exactly its strength and its trap.
+
+**PR curve** plots Precision vs Recall. **PR-AUC (average precision)** depends on prevalence and reflects what an operator actually experiences on an imbalanced problem.
+
+```python
+from sklearn.metrics import roc_auc_score, average_precision_score
+
+y_proba = model.predict_proba(X_val)[:, 1]
+print(f"ROC-AUC: {roc_auc_score(y_val, y_proba):.4f}")
+print(f"PR-AUC : {average_precision_score(y_val, y_proba):.4f}")
+print(f"Baseline PR-AUC (prevalence): {y_val.mean():.4f}")
+```
+
+Always print the prevalence baseline. A PR-AUC of 0.30 is excellent at 1% prevalence and terrible at 40%.
+
+### The worked example every interviewer wants
+
+100,000 transactions, 100 are fraud (0.1%). A model flags 1,000 transactions and catches 90 frauds.
+
+- Recall = 90/100 = **90%**
+- Precision = 90/1000 = **9%**
+- FPR = 910/99,900 = **0.9%** → ROC looks superb
+- Accuracy = 99.0% — *worse than predicting "never fraud"* (99.9%)
+
+ROC-AUC will read ~0.98 here because FPR is normalized by the huge negative class. PR-AUC honestly reports that 91% of the analyst's review queue is noise. **On heavy imbalance, report PR-AUC; use ROC-AUC only as a secondary ranking check.**
+
+---
+
+## Threshold Selection
+
+Models output scores; decisions need a cutoff. `0.5` is a default, not an answer.
+
+```python
+import numpy as np
+from sklearn.metrics import precision_recall_curve
+
+precision, recall, thresholds = precision_recall_curve(y_val, y_proba)
+
+# Option A: maximize F1
+f1 = 2 * precision * recall / (precision + recall + 1e-12)
+best_f1_threshold = thresholds[np.argmax(f1[:-1])]
+
+# Option B: highest recall subject to a precision floor the business set
+mask = precision[:-1] >= 0.80
+best_recall_threshold = thresholds[mask][np.argmax(recall[:-1][mask])] if mask.any() else None
+
+# Option C: minimize expected cost — the most defensible in an interview
+COST_FN, COST_FP = 500, 10     # e.g. missed fraud vs wasted analyst review
+
+def expected_cost(threshold):
+    predicted = y_proba >= threshold
+    false_negatives = ((~predicted) & (y_val == 1)).sum()
+    false_positives = ((predicted) & (y_val == 0)).sum()
+    return false_negatives * COST_FN + false_positives * COST_FP
+
+best_cost_threshold = thresholds[int(np.argmin([expected_cost(t) for t in thresholds]))]
+```
+
+Option C is the strongest answer: express the decision as expected cost, and the optimal threshold falls out of the cost ratio rather than a convention. Also account for **capacity**: if analysts can review 500 cases a day, the threshold is whatever produces 500 alerts, regardless of what F1 prefers.
+
+Tune the threshold on a **validation** set and report final numbers on a **test** set. Choosing the threshold on the test set is a subtle but real form of overfitting.
+
+---
+
+## Probability Calibration
+
+A model is calibrated if, among predictions of 0.7, roughly 70% are positive. Ranking quality (AUC) and calibration are independent: a model can rank perfectly and still be systematically overconfident.
+
+```python
+from sklearn.calibration import CalibratedClassifierCV, calibration_curve
+from sklearn.metrics import brier_score_loss
+
+prob_true, prob_pred = calibration_curve(y_val, y_proba, n_bins=10, strategy='quantile')
+# Perfect calibration lies on y = x; plot and look at the deviation.
+
+calibrated = CalibratedClassifierCV(model, method='isotonic', cv='prefit')
+calibrated.fit(X_cal, y_cal)      # a held-out calibration set, not the training set
+print(f"Brier before: {brier_score_loss(y_val, y_proba):.4f}")
+print(f"Brier after : {brier_score_loss(y_val, calibrated.predict_proba(X_val)[:,1]):.4f}")
+```
+
+| Method | Shape assumed | Data needed | Notes |
+|---|---|---|---|
+| **Platt scaling** (sigmoid) | Sigmoid distortion | Small (~hundreds) | Good for SVMs and small calibration sets |
+| **Isotonic regression** | Any monotonic | Larger (~1000+) | More flexible, overfits on small sets |
+| **Temperature scaling** | Single scalar on logits | Very small | Standard for neural networks, preserves argmax |
+
+Which models need calibration? SVMs and naive Bayes are badly calibrated by construction. Boosted trees are pushed toward 0 and 1 by the loss. Random Forests are compressed toward the middle (averaging pulls away from extremes). Logistic regression trained with log loss is usually close to calibrated already. Anything trained with class reweighting or on a resampled dataset is miscalibrated by design and must be corrected before its scores feed a downstream cost calculation.
+
+Calibration matters when the score is **used as a number** — expected-value decisions, pricing, ranking against a cost threshold, or feeding another model. If you only threshold once, ranking is enough.
+
+---
+
+## Regression Metrics
+
+| Metric | Formula | Units | Sensitivity to outliers | Use when |
+|---|---|---|---|---|
+| MAE | `mean|y - ŷ|` | Target units | Low | Outliers are noise; you want the median behavior |
+| MSE | `mean(y - ŷ)²` | Squared units | High | Large errors are disproportionately bad |
+| RMSE | `√MSE` | Target units | High | Same as MSE but readable |
+| MAPE | `mean|y-ŷ|/|y|` | Percent | Medium | Comparing across scales — breaks near `y=0` |
+| SMAPE | symmetric variant | Percent | Medium | MAPE with bounded blow-up |
+| R² | `1 - SSE/SST` | Unitless | High | Explaining variance vs the mean baseline |
+| Quantile / pinch loss | asymmetric | Target units | Tunable | Over- and under-prediction cost differently |
+| Huber | quadratic then linear | Target units | Medium | Want MSE's gradients with MAE's robustness |
+
+Two things worth saying out loud in an interview:
+
+- **MAE optimizes the median, MSE optimizes the mean.** If you train with MSE on a right-skewed target (revenue, latency), the model systematically over-predicts the typical case. That's a modeling choice, not a bug — but it should be deliberate.
+- **R² can be negative** (worse than predicting the mean) and always increases when you add features, so use adjusted R² when comparing models with different feature counts. R² is also not comparable across datasets with different target variance.
+
+For skewed positive targets, training on `log1p(y)` and reporting RMSE in log space (RMSLE) penalizes under-prediction more than over-prediction and stops a few huge values from dominating the loss.
+
+---
+
+## Ranking and Recommendation Metrics
+
+| Metric | What it captures |
+|---|---|
+| **Precision@k** | Fraction of the top-k that are relevant — matches a fixed-size UI slot |
+| **Recall@k** | Fraction of all relevant items appearing in top-k — the standard retrieval metric |
+| **MRR** | `mean(1 / rank of first relevant)` — right for "one correct answer" tasks |
+| **MAP** | Mean average precision — rewards relevant items ranked higher |
+| **NDCG@k** | Discounted cumulative gain, normalized — handles graded relevance and position discount |
+| **Hit rate@k** | Any relevant item in top-k — coarse but interpretable |
+
+NDCG is the default for search and recommendation because it handles both *graded* relevance (a 4-star match beats a 2-star match) and *position discount* (rank 1 is worth more than rank 10):
+
+```
+DCG@k = Σ (2^rel_i - 1) / log₂(i + 1)      NDCG@k = DCG@k / IDCG@k
+```
+
+These same metrics apply to RAG retrieval evaluation — recall@k on the retriever is usually the first thing to measure when a RAG system gives wrong answers.
+
+---
+
+## Cross-Validation Strategies
+
+| Strategy | When | Why |
+|---|---|---|
+| **K-Fold** | i.i.d. data, plenty of it | Standard, low bias |
+| **Stratified K-Fold** | Classification, especially imbalanced | Preserves class ratio per fold |
+| **TimeSeriesSplit** | Any temporal data | Train always precedes validation |
+| **GroupKFold** | Repeated entities (users, patients, sessions) | Keeps a group entirely in one fold |
+| **StratifiedGroupKFold** | Both of the above | Rare in libraries, common in reality |
+| **Nested CV** | Reporting a performance estimate *and* tuning | Outer loop estimates, inner loop tunes |
+| **LOOCV** | Very small datasets | Nearly unbiased, high variance, expensive |
+
+```python
+from sklearn.model_selection import TimeSeriesSplit, GroupKFold, cross_val_score
+
+# Temporal: fold i trains on [0..i] and validates on [i+1]
+tscv = TimeSeriesSplit(n_splits=5, gap=7)   # `gap` guards against label leakage windows
+
+# Grouped: no user appears in both train and validation
+gkf = GroupKFold(n_splits=5)
+scores = cross_val_score(model, X, y, groups=user_ids, cv=gkf, scoring='roc_auc')
+print(f"AUC {scores.mean():.4f} ± {scores.std():.4f}")
+```
+
+Always report the **standard deviation** across folds, not just the mean. A model scoring 0.82 ± 0.01 and one scoring 0.84 ± 0.06 are not clearly different, and saying so is a strong interview signal.
+
+**Nested CV** exists because tuning on the same folds you report from is optimistically biased: the hyperparameter search has already seen every validation fold. Outer loop for the estimate, inner loop for tuning.
+
+---
+
+## Offline vs Online Metrics
+
+Offline metrics are proxies. The model exists to move a business number.
+
+| Layer | Examples | Measured by |
+|---|---|---|
+| **Model metrics** | AUC, RMSE, NDCG | Offline holdout |
+| **System metrics** | p99 latency, error rate, cost per 1k predictions | Production telemetry |
+| **Product metrics** | CTR, conversion, session length, task completion | A/B test |
+| **Business metrics** | Revenue, retention, fraud loss, support cost | A/B test + finance |
+
+Proxies diverge from outcomes. A recommender optimizing CTR learns clickbait; a fraud model optimizing AUC may improve on the frauds you already catch. The standard answer: pick one primary online metric, define **guardrail metrics** that must not regress (latency, complaint rate, revenue per session), and validate offline gains with an A/B test before you believe them.
+
+Include a **degradation plan** too: metrics drift as the input distribution moves, so define what a regression looks like and what triggers a rollback.
+
+---
+
+## Metric Selection Cheat Sheet
+
+| Problem | Primary metric | Why |
+|---|---|---|
+| Balanced binary classification | ROC-AUC + accuracy | Both meaningful when classes are balanced |
+| Fraud / rare-event detection | PR-AUC, recall @ fixed precision | ROC hides the false-positive burden |
+| Medical screening | Recall at a specificity floor | Misses are far costlier than follow-ups |
+| Spam filtering | Precision at a recall floor | A blocked legitimate email is expensive |
+| Credit scoring | AUC + calibration (Brier) | Scores feed pricing, so they must be real probabilities |
+| Demand forecasting | MAE or quantile loss | Robust to spikes; over/under stock costs differ |
+| Revenue prediction | RMSLE or MAE | Skewed target, relative error matters |
+| Search / recommendation | NDCG@k, recall@k | Position and graded relevance matter |
+| RAG retrieval | Recall@k, MRR | Generation cannot fix what retrieval missed |
+| LLM generation | Task success rate, LLM-as-judge + human review | No single automatic metric is sufficient |
+
+---
+
+## Interview Q&A
+
+#### Your model has 99% accuracy. Is it good?
+
+Unanswerable without the class balance and the cost structure. If 99% of examples are negative, predicting "always negative" scores 99% and has zero value — accuracy is measuring the prior, not the model. I'd ask for prevalence, then report PR-AUC against the prevalence baseline, plus recall at whatever precision the business can tolerate. I'd also ask what a false positive and a false negative each cost, because that determines both the metric and the operating threshold.
+
+#### When would you use ROC-AUC over PR-AUC, and vice versa?
+
+ROC-AUC when classes are roughly balanced, when both classes matter symmetrically, or when I need a prevalence-invariant number to compare the same model across populations with different base rates. PR-AUC when positives are rare and I care about the quality of the positive predictions specifically.
+
+The mechanism: ROC's x-axis is FPR = FP/(FP+TN). With a huge negative class, thousands of false positives barely move FPR, so ROC stays optimistic while precision collapses. PR-AUC uses FP/(TP+FP), which has no large denominator to hide behind.
+
+#### What is probability calibration, and when do you need it?
+
+Calibration means predicted probabilities match observed frequencies — of the cases scored 0.7, about 70% should be positive. You need it whenever the score is consumed as a number rather than as a rank: expected-value decisions, risk pricing, thresholds derived from costs, or feeding the score into a downstream model or human judgment.
+
+You don't strictly need it when you only rank (recommendations shown in order) or threshold once at an empirically tuned cutoff. Check with a reliability diagram and the Brier score; fix with Platt scaling (small data), isotonic regression (larger data), or temperature scaling (neural networks) — always fit on a held-out calibration set.
+
+#### Why is a random train/test split wrong for time series?
+
+It leaks the future into the past. A random split lets the model train on Tuesday and Thursday while validating on Wednesday, so it can exploit information no production model would have — trends, same-day correlated events, or explicit lag features computed over the whole series. Validation scores look great and production degrades immediately.
+
+Use a forward-chaining split (`TimeSeriesSplit`), evaluate on strictly later data than training, and add a `gap` when the label takes time to materialize — e.g. a 30-day churn label means the last 30 days of training data would not have been labeled yet in production.
+
+#### Explain the precision-recall tradeoff and how you pick a threshold.
+
+Both derive from one score and one cutoff. Lower the threshold and you predict positive more often: recall rises, precision falls. The curve is a property of the model's ranking; the threshold is a business decision on top of it.
+
+I pick it by expected cost when costs are known: choose the threshold minimizing `COST_FN × FN + COST_FP × FP` on validation data. When costs aren't quantified, I anchor on an operational constraint — reviewer capacity, or a precision floor stakeholders will accept — and take the best recall subject to it. F1-optimal is a fallback for when no business context exists at all, which is rarer than people assume.
+
+#### What's the difference between MAE and RMSE, and when does the choice matter?
+
+RMSE squares errors before averaging, so a single error of 10 contributes as much as 100 errors of 1. MAE weighs every error linearly. Consequently RMSE ≥ MAE always, and the gap grows with error variance.
+
+The choice matters when outliers exist and their treatment is a real decision. Training on MSE fits the conditional mean and chases outliers; training on MAE fits the conditional median and ignores them. For delivery-time prediction, a rare 3-hour delay may genuinely be catastrophic (RMSE), while for sensor data the same spike is measurement noise (MAE, or Huber for a middle ground).
+
+#### How do you evaluate a model when labels arrive weeks later?
+
+Three moves, used together:
+1. **Proxy metrics available immediately** — prediction distribution shift, feature drift (PSI/KL), and model confidence, monitored for anomalies that predict a quality drop.
+2. **A delayed evaluation pipeline** — join predictions to labels as they arrive and backfill true performance on a rolling basis, accepting that today's number describes the model from weeks ago.
+3. **A fast-label subsample** — for some domains you can buy or manually label a small sample quickly for a same-week signal.
+
+I'd also make sure the training setup respects the delay: features must be as-of prediction time and the CV gap must equal the label latency, or offline scores will be unreachable in production.
+
+#### Your offline AUC improved but the A/B test is flat. What happened?
+
+The usual suspects, in the order I'd check them:
+- **Train/serve skew**: features computed differently offline and online — the most common cause by a wide margin.
+- **The offline metric is the wrong proxy**: AUC improved on easy examples that don't change any decision, or the threshold means the ranking improvement never crosses into a different action.
+- **The improvement is inside noise**: the A/B test may be underpowered for an effect that size; check the minimum detectable effect before concluding "flat".
+- **Leakage offline**: the offline gain was never real.
+- **System effects**: latency added by the new model reduced engagement enough to cancel the quality gain.
+- **Position/feedback effects**: the model's own past outputs shaped the training data, so offline replay overestimates the gain.
+
+#### Why report standard deviation across CV folds?
+
+Because a single mean hides instability. Fold variance tells you whether a difference between two models is real, whether the dataset has heterogeneous subgroups (one fold much worse usually means a distinct segment the model fails on), and whether the model is sensitive to which rows it sees. If model A is 0.84 ± 0.06 and model B is 0.82 ± 0.01, B may be the better production choice — the paired difference across folds, not the raw means, is what to test.
+
+#### What is data leakage, and how do you detect it?
+
+Leakage is any information in training features that would not be available at prediction time in production. Common forms: a feature computed after the label event, target encoding fit before the split, scaler or imputer fit on the full dataset, duplicate rows spanning the split, and IDs correlated with the label.
+
+Detection signals: implausibly high scores, one feature dominating importance, a large gap between offline and online performance, and a metric that collapses when the split is made temporal instead of random. The structural fix is to build every transformation inside a `Pipeline` fit only on the training fold, and to write features with explicit as-of timestamps.
+
+---
+
+## Common Pitfalls
+
+| Pitfall | Why it hurts | Fix |
+|---|---|---|
+| Accuracy on imbalanced data | The majority-class baseline already scores high | PR-AUC, recall at fixed precision, MCC |
+| Fitting the scaler/imputer before splitting | Test statistics leak into training | Fit inside a `Pipeline` per fold |
+| Tuning the threshold on the test set | Test performance becomes optimistic | Tune on validation, report on test |
+| Comparing R² across different datasets | R² depends on target variance | Compare RMSE/MAE in the same units |
+| Ignoring calibration when scores drive decisions | Expected-value math is wrong even with great AUC | Reliability diagram + isotonic/Platt |
+| Reporting only the CV mean | Hides instability and subgroup failure | Report mean ± std, inspect worst fold |
+| Random split with repeated users/sessions | The same entity in train and test inflates scores | `GroupKFold` on the entity |
+| MAPE on targets near zero | Division by ~0 explodes the metric | SMAPE, MAE, or a relative-error variant |
+| Optimizing a proxy without guardrails | CTR up, satisfaction down | Primary metric + explicit guardrail metrics |
+| One aggregate metric for all segments | Masks failure on a minority segment | Slice metrics by segment and report the worst |
+
+---
+
+## Related Topics
+
+- [Ensemble Methods and Gradient Boosting](./intro_ensemble_methods.md)
+- [Statistics and Probability](./intro_statistics_probability.md)
+- [Feature Engineering](./intro_feature_engineering.md)
+- [A/B Testing](../mlops/intro_ab_testing.md)
+- [Model Monitoring](../mlops/intro_model_monitoring.md)
+- [LLM Evaluation](../mlops/intro_llm_evaluation.md)
+- [Classical ML Overview](./README.md)

--- a/coding_challenges/ml_coding_challenges.md
+++ b/coding_challenges/ml_coding_challenges.md
@@ -1,0 +1,634 @@
+# ML Coding Challenges — Implement From Scratch
+
+Many ML interviews include a round where you implement an algorithm with NumPy only — no scikit-learn, no PyTorch. The point is not memorization; it is whether you understand the math well enough to translate it into code, and whether you can reason about shapes, numerical stability, and complexity out loud.
+
+Each challenge below gives the problem, a reference solution, and the follow-up questions interviewers actually ask.
+
+---
+
+## Table of Contents
+1. [How to Approach These Rounds](#how-to-approach-these-rounds)
+2. [Linear Regression with Gradient Descent](#1-linear-regression-with-gradient-descent)
+3. [Logistic Regression](#2-logistic-regression)
+4. [K-Means](#3-k-means)
+5. [K-Nearest Neighbors](#4-k-nearest-neighbors)
+6. [Decision Tree Split (Gini and Entropy)](#5-decision-tree-split-gini-and-entropy)
+7. [Train/Test Split and K-Fold Cross-Validation](#6-traintest-split-and-k-fold-cross-validation)
+8. [Metrics from Scratch](#7-metrics-from-scratch)
+9. [PCA](#8-pca)
+10. [Softmax and Cross-Entropy (Numerically Stable)](#9-softmax-and-cross-entropy-numerically-stable)
+11. [A Two-Layer Neural Network with Backprop](#10-a-two-layer-neural-network-with-backprop)
+12. [Scaled Dot-Product Attention](#11-scaled-dot-product-attention)
+13. [Cosine Similarity Search](#12-cosine-similarity-search)
+14. [Text Chunking with Overlap](#13-text-chunking-with-overlap)
+15. [Rate Limiter with Exponential Backoff](#14-rate-limiter-with-exponential-backoff)
+16. [Reciprocal Rank Fusion](#15-reciprocal-rank-fusion)
+17. [Complexity Reference](#complexity-reference)
+18. [Common Pitfalls](#common-pitfalls)
+19. [Related Topics](#related-topics)
+
+---
+
+## How to Approach These Rounds
+
+1. **Clarify the contract first.** Input shapes, dtypes, whether a bias term is expected, what happens on empty input. Thirty seconds here prevents a rewrite.
+2. **State the math before typing.** "Gradient of MSE with respect to w is `2/n · Xᵀ(Xw - y)`" — this earns credit even if the code has a bug.
+3. **Write shapes as comments.** `# (n, d) @ (d,) -> (n,)`. Shape errors are the number one failure in these rounds, and annotating prevents most of them.
+4. **Vectorize, but get it correct first.** A working loop beats a broken broadcast. Then say "this loop is `O(n·k)`; here's the vectorized version" and rewrite it.
+5. **Mention numerical stability unprompted.** Subtract the max before `exp`, clip before `log`, add epsilon to denominators. Interviewers weight this heavily because it separates people who have shipped models from people who have read about them.
+6. **Test on a tiny example out loud.** Two points, two clusters — walk through one iteration.
+
+---
+
+## 1. Linear Regression with Gradient Descent
+
+**Problem**: Implement linear regression trained by batch gradient descent. Support a bias term.
+
+```python
+import numpy as np
+
+class LinearRegressionGD:
+    def __init__(self, lr=0.01, n_iters=1000, fit_intercept=True):
+        self.lr = lr
+        self.n_iters = n_iters
+        self.fit_intercept = fit_intercept
+
+    def _add_bias(self, X):
+        return np.c_[np.ones(len(X)), X] if self.fit_intercept else X
+
+    def fit(self, X, y):
+        X = self._add_bias(np.asarray(X, dtype=float))   # (n, d+1)
+        y = np.asarray(y, dtype=float)                   # (n,)
+        n, d = X.shape
+        self.w = np.zeros(d)
+        self.history = []
+
+        for _ in range(self.n_iters):
+            y_pred = X @ self.w                          # (n, d) @ (d,) -> (n,)
+            error = y_pred - y                           # (n,)
+            grad = (2 / n) * (X.T @ error)               # (d, n) @ (n,) -> (d,)
+            self.w -= self.lr * grad
+            self.history.append(np.mean(error ** 2))
+        return self
+
+    def predict(self, X):
+        return self._add_bias(np.asarray(X, dtype=float)) @ self.w
+```
+
+**Closed form** (the normal equation) — know both:
+
+```python
+def fit_closed_form(X, y, ridge=0.0):
+    """w = (XᵀX + λI)⁻¹ Xᵀy — O(d³), exact, no learning rate."""
+    X = np.c_[np.ones(len(X)), X]
+    d = X.shape[1]
+    reg = ridge * np.eye(d)
+    reg[0, 0] = 0.0                              # never penalize the intercept
+    return np.linalg.solve(X.T @ X + reg, X.T @ y)   # solve beats inv() — faster and stabler
+```
+
+**Follow-ups**
+- *When use gradient descent over the closed form?* The normal equation is `O(d³)` and needs `XᵀX` in memory, so it's impractical above a few thousand features; it also requires `XᵀX` to be invertible, which fails with collinear features (ridge fixes that). Gradient descent scales to large `n` and `d`, works out-of-core, and generalizes to non-convex models.
+- *Why `np.linalg.solve` instead of `np.linalg.inv`?* Solving the system directly is roughly 2x faster and numerically more stable — explicitly inverting amplifies conditioning problems.
+- *What if the loss diverges?* Learning rate too high, or features on wildly different scales. Standardize, or lower the LR.
+
+---
+
+## 2. Logistic Regression
+
+**Problem**: Binary logistic regression with gradient descent and L2 regularization.
+
+```python
+class LogisticRegressionGD:
+    def __init__(self, lr=0.1, n_iters=1000, l2=0.0):
+        self.lr, self.n_iters, self.l2 = lr, n_iters, l2
+
+    @staticmethod
+    def _sigmoid(z):
+        # Stable: avoid exp() overflow on large-magnitude z
+        out = np.empty_like(z, dtype=float)
+        pos, neg = z >= 0, z < 0
+        out[pos] = 1.0 / (1.0 + np.exp(-z[pos]))
+        ez = np.exp(z[neg])
+        out[neg] = ez / (1.0 + ez)
+        return out
+
+    def fit(self, X, y):
+        X = np.c_[np.ones(len(X)), np.asarray(X, dtype=float)]
+        y = np.asarray(y, dtype=float)
+        n, d = X.shape
+        self.w = np.zeros(d)
+
+        for _ in range(self.n_iters):
+            p = self._sigmoid(X @ self.w)
+            grad = (X.T @ (p - y)) / n            # same form as linear regression!
+            grad[1:] += self.l2 * self.w[1:]      # no penalty on the intercept
+            self.w -= self.lr * grad
+        return self
+
+    def predict_proba(self, X):
+        return self._sigmoid(np.c_[np.ones(len(X)), X] @ self.w)
+
+    def predict(self, X, threshold=0.5):
+        return (self.predict_proba(X) >= threshold).astype(int)
+```
+
+**Follow-ups**
+- *Why is the gradient identical in form to linear regression's?* Both are generalized linear models; for a GLM with the canonical link, the gradient of the log-likelihood is always `Xᵀ(prediction - y)`. Nice result to state.
+- *Why not squared error for classification?* With a sigmoid, squared error is non-convex in `w` and its gradient vanishes when predictions are confidently wrong (the sigmoid saturates). Log loss is convex and its gradient stays proportional to the error.
+- *How do you extend to multiclass?* Softmax regression with cross-entropy, or one-vs-rest.
+
+---
+
+## 3. K-Means
+
+**Problem**: Implement K-Means with k-means++ initialization.
+
+```python
+def kmeans(X, k, n_iters=100, tol=1e-4, seed=0):
+    rng = np.random.default_rng(seed)
+    X = np.asarray(X, dtype=float)
+    n, d = X.shape
+
+    # --- k-means++ init: spread initial centroids by D² sampling ---
+    centroids = [X[rng.integers(n)]]
+    for _ in range(k - 1):
+        d2 = np.min(((X[:, None, :] - np.array(centroids)[None, :, :]) ** 2).sum(-1), axis=1)
+        probs = d2 / d2.sum()
+        centroids.append(X[rng.choice(n, p=probs)])
+    centroids = np.array(centroids)                      # (k, d)
+
+    for _ in range(n_iters):
+        # Assignment: squared distance from every point to every centroid
+        dists = ((X[:, None, :] - centroids[None, :, :]) ** 2).sum(-1)   # (n, k)
+        labels = dists.argmin(axis=1)                                    # (n,)
+
+        # Update: mean of each cluster; keep old centroid if a cluster empties
+        new_centroids = np.array([
+            X[labels == j].mean(axis=0) if np.any(labels == j) else centroids[j]
+            for j in range(k)
+        ])
+        if np.linalg.norm(new_centroids - centroids) < tol:
+            centroids = new_centroids
+            break
+        centroids = new_centroids
+
+    inertia = ((X - centroids[labels]) ** 2).sum()
+    return labels, centroids, inertia
+```
+
+**Follow-ups**
+- *Memory problem with this distance computation?* `X[:, None, :] - centroids[None, :, :]` materializes an `(n, k, d)` array. For n=1M, k=100, d=128 that's 51 GB. Use the identity `‖x-c‖² = ‖x‖² - 2x·c + ‖c‖²` to compute distances with one `(n,d)@(d,k)` matmul.
+- *Why k-means++?* Random initialization frequently converges to a poor local minimum; k-means++ samples each new centroid proportional to squared distance from existing ones, giving an `O(log k)` approximation guarantee in expectation and much more stable results.
+- *Convergence?* Both steps monotonically decrease inertia and there are finitely many assignments, so it always converges — to a local optimum, which is why you run it with several seeds (`n_init`).
+- *Empty cluster?* Reinitialize it to the point farthest from its centroid, or keep the old centroid (as above).
+
+---
+
+## 4. K-Nearest Neighbors
+
+```python
+def knn_predict(X_train, y_train, X_test, k=5, task='classification'):
+    X_train, X_test = np.asarray(X_train, float), np.asarray(X_test, float)
+
+    # ‖a - b‖² = ‖a‖² - 2a·b + ‖b‖²  — avoids the (n_test, n_train, d) tensor
+    d2 = (
+        (X_test ** 2).sum(axis=1)[:, None]
+        - 2 * X_test @ X_train.T
+        + (X_train ** 2).sum(axis=1)[None, :]
+    )                                                    # (n_test, n_train)
+
+    idx = np.argpartition(d2, kth=k - 1, axis=1)[:, :k]  # O(n) per row, not O(n log n)
+    neighbor_labels = np.asarray(y_train)[idx]           # (n_test, k)
+
+    if task == 'regression':
+        return neighbor_labels.mean(axis=1)
+    # Majority vote
+    return np.array([np.bincount(row).argmax() for row in neighbor_labels])
+```
+
+**Follow-ups**
+- *Why `argpartition` over `argsort`?* You need the k smallest, not a full ordering — `O(n)` vs `O(n log n)` per row.
+- *Why does KNN fail in high dimensions?* Distance concentration: as `d` grows, the ratio between nearest and farthest neighbor distances approaches 1, so "nearest" stops being meaningful. Reduce dimensions first (PCA) or use a learned metric.
+- *Scaling required?* Yes — KNN is distance-based, so a feature measured in dollars swamps one in fractions. Always standardize.
+
+---
+
+## 5. Decision Tree Split (Gini and Entropy)
+
+**Problem**: Find the best split for a node.
+
+```python
+def gini(y):
+    if len(y) == 0:
+        return 0.0
+    p = np.bincount(y) / len(y)
+    return 1.0 - (p ** 2).sum()
+
+def entropy(y):
+    if len(y) == 0:
+        return 0.0
+    p = np.bincount(y) / len(y)
+    p = p[p > 0]                       # avoid log(0)
+    return -(p * np.log2(p)).sum()
+
+def best_split(X, y, criterion=gini):
+    n, d = X.shape
+    parent_impurity = criterion(y)
+    best = {'gain': -np.inf, 'feature': None, 'threshold': None}
+
+    for feature in range(d):
+        # Candidate thresholds: midpoints between consecutive unique values
+        values = np.unique(X[:, feature])
+        thresholds = (values[:-1] + values[1:]) / 2
+
+        for t in thresholds:
+            left = X[:, feature] <= t
+            n_left = left.sum()
+            if n_left == 0 or n_left == n:
+                continue
+            # Weighted child impurity
+            child = (n_left / n) * criterion(y[left]) + ((n - n_left) / n) * criterion(y[~left])
+            gain = parent_impurity - child
+            if gain > best['gain']:
+                best = {'gain': gain, 'feature': feature, 'threshold': t}
+    return best
+```
+
+**Follow-ups**
+- *Gini vs entropy?* They agree on the chosen split the overwhelming majority of the time. Gini is cheaper (no logarithm) and is scikit-learn's default; entropy is grounded in information theory. Not a decision worth agonizing over.
+- *Complexity?* This is `O(d · n²)` because of the inner loop over thresholds recomputing impurity. Sorting each feature once and updating class counts incrementally as the threshold sweeps gives `O(d · n log n)`. Say this — it's the optimization interviewers look for.
+- *How would you handle continuous vs categorical?* Continuous uses thresholds as above; categorical either uses subset splits (exponential, so usually restricted) or is ordered by mean target value first.
+
+---
+
+## 6. Train/Test Split and K-Fold Cross-Validation
+
+```python
+def train_test_split_manual(X, y, test_size=0.2, stratify=False, seed=0):
+    rng = np.random.default_rng(seed)
+    n = len(X)
+
+    if not stratify:
+        idx = rng.permutation(n)
+        cut = int(n * (1 - test_size))
+        train_idx, test_idx = idx[:cut], idx[cut:]
+    else:
+        train_idx, test_idx = [], []
+        for cls in np.unique(y):                      # preserve class ratio per split
+            cls_idx = rng.permutation(np.where(y == cls)[0])
+            cut = int(len(cls_idx) * (1 - test_size))
+            train_idx.extend(cls_idx[:cut])
+            test_idx.extend(cls_idx[cut:])
+        train_idx, test_idx = np.array(train_idx), np.array(test_idx)
+
+    return X[train_idx], X[test_idx], y[train_idx], y[test_idx]
+
+
+def k_fold_indices(n, k=5, seed=0):
+    idx = np.random.default_rng(seed).permutation(n)
+    folds = np.array_split(idx, k)                    # handles n not divisible by k
+    for i in range(k):
+        val = folds[i]
+        train = np.concatenate([folds[j] for j in range(k) if j != i])
+        yield train, val
+```
+
+**Follow-up**: *What changes for time series?* Nothing about this works — shuffling leaks the future. Use forward chaining: fold `i` trains on `[0..i]` and validates on `[i+1]`, with a gap equal to the label latency.
+
+---
+
+## 7. Metrics from Scratch
+
+```python
+def confusion(y_true, y_pred):
+    y_true, y_pred = np.asarray(y_true), np.asarray(y_pred)
+    tp = int(((y_pred == 1) & (y_true == 1)).sum())
+    fp = int(((y_pred == 1) & (y_true == 0)).sum())
+    fn = int(((y_pred == 0) & (y_true == 1)).sum())
+    tn = int(((y_pred == 0) & (y_true == 0)).sum())
+    return tp, fp, fn, tn
+
+def precision_recall_f1(y_true, y_pred, eps=1e-12):
+    tp, fp, fn, _ = confusion(y_true, y_pred)
+    precision = tp / (tp + fp + eps)
+    recall = tp / (tp + fn + eps)
+    f1 = 2 * precision * recall / (precision + recall + eps)
+    return precision, recall, f1
+
+def roc_auc(y_true, y_score):
+    """AUC == P(score of a random positive > score of a random negative).
+    Computed via the rank-sum (Mann-Whitney U) identity — O(n log n), no curve needed."""
+    y_true = np.asarray(y_true)
+    order = np.argsort(y_score)
+    ranks = np.empty(len(y_score), dtype=float)
+    ranks[order] = np.arange(1, len(y_score) + 1)
+
+    # Average ranks within ties so tied scores don't bias the result
+    scores_sorted = np.asarray(y_score)[order]
+    i = 0
+    while i < len(scores_sorted):
+        j = i
+        while j + 1 < len(scores_sorted) and scores_sorted[j + 1] == scores_sorted[i]:
+            j += 1
+        if j > i:
+            ranks[order[i:j + 1]] = (i + j + 2) / 2
+        i = j + 1
+
+    n_pos, n_neg = int(y_true.sum()), int((1 - y_true).sum())
+    if n_pos == 0 or n_neg == 0:
+        return float('nan')
+    return (ranks[y_true == 1].sum() - n_pos * (n_pos + 1) / 2) / (n_pos * n_neg)
+```
+
+**Follow-up**: *Why the rank-sum formula rather than integrating the ROC curve?* It's the same quantity, computed in one sort with no threshold sweep, and it makes the probabilistic interpretation of AUC explicit.
+
+---
+
+## 8. PCA
+
+```python
+def pca(X, n_components):
+    X = np.asarray(X, dtype=float)
+    X_centered = X - X.mean(axis=0)                  # centering is mandatory
+
+    # SVD is more numerically stable than eigendecomposing the covariance matrix
+    U, S, Vt = np.linalg.svd(X_centered, full_matrices=False)
+
+    components = Vt[:n_components]                   # (n_components, d)
+    explained_variance = (S ** 2) / (len(X) - 1)
+    explained_ratio = explained_variance / explained_variance.sum()
+
+    X_transformed = X_centered @ components.T        # (n, n_components)
+    return X_transformed, components, explained_ratio[:n_components]
+```
+
+**Follow-ups**
+- *Why SVD over eigendecomposition of `XᵀX`?* Forming `XᵀX` squares the condition number, losing precision; SVD works on `X` directly. It's also cheaper when `d >> n`.
+- *Must you standardize as well as center?* Center always. Standardize when features are on different scales — otherwise the component with the largest units dominates the variance and PCA just finds that axis.
+- *Choosing `n_components`?* Cumulative explained variance (e.g. 95%), an elbow in the scree plot, or downstream task performance.
+
+---
+
+## 9. Softmax and Cross-Entropy (Numerically Stable)
+
+```python
+def softmax(z, axis=-1):
+    z = np.asarray(z, dtype=float)
+    z_shifted = z - np.max(z, axis=axis, keepdims=True)   # prevents exp() overflow
+    e = np.exp(z_shifted)
+    return e / e.sum(axis=axis, keepdims=True)
+
+def cross_entropy(logits, labels, eps=1e-12):
+    """logits: (n, k) raw scores. labels: (n,) integer class indices."""
+    probs = softmax(logits, axis=1)
+    n = len(labels)
+    return -np.log(probs[np.arange(n), labels] + eps).mean()
+
+def cross_entropy_grad(logits, labels):
+    """dL/dlogits = (softmax(logits) - onehot(labels)) / n — strikingly simple."""
+    probs = softmax(logits, axis=1)
+    n = len(labels)
+    probs[np.arange(n), labels] -= 1
+    return probs / n
+```
+
+**Follow-ups**
+- *Why subtract the max?* `softmax(z) == softmax(z - c)` for any constant `c`, and subtracting the max caps the largest exponent at `e^0 = 1`, preventing overflow. Costs nothing, prevents NaNs. Interviewers specifically watch for this.
+- *Why do frameworks fuse softmax and cross-entropy?* `log(softmax(z))` computed separately loses precision when probabilities are tiny; the fused log-sum-exp form is stable, which is why PyTorch's `CrossEntropyLoss` takes raw logits and applying softmax first is a bug.
+
+---
+
+## 10. A Two-Layer Neural Network with Backprop
+
+```python
+class TwoLayerNet:
+    """input -> Linear -> ReLU -> Linear -> softmax cross-entropy"""
+
+    def __init__(self, d_in, d_hidden, d_out, seed=0):
+        rng = np.random.default_rng(seed)
+        self.W1 = rng.normal(0, np.sqrt(2 / d_in), (d_in, d_hidden))   # He init for ReLU
+        self.b1 = np.zeros(d_hidden)
+        self.W2 = rng.normal(0, np.sqrt(2 / d_hidden), (d_hidden, d_out))
+        self.b2 = np.zeros(d_out)
+
+    def forward(self, X):
+        self.X = X
+        self.z1 = X @ self.W1 + self.b1        # (n, h)
+        self.a1 = np.maximum(0, self.z1)       # ReLU
+        self.z2 = self.a1 @ self.W2 + self.b2  # (n, k) logits
+        return self.z2
+
+    def backward(self, labels, lr=0.01):
+        n = len(labels)
+        # dL/dz2 for softmax + cross-entropy
+        dz2 = softmax(self.z2, axis=1)
+        dz2[np.arange(n), labels] -= 1
+        dz2 /= n                                # (n, k)
+
+        dW2 = self.a1.T @ dz2                   # (h, n) @ (n, k) -> (h, k)
+        db2 = dz2.sum(axis=0)
+
+        da1 = dz2 @ self.W2.T                   # (n, k) @ (k, h) -> (n, h)
+        dz1 = da1 * (self.z1 > 0)               # ReLU derivative is the mask
+
+        dW1 = self.X.T @ dz1
+        db1 = dz1.sum(axis=0)
+
+        for param, grad in ((self.W1, dW1), (self.b1, db1), (self.W2, dW2), (self.b2, db2)):
+            param -= lr * grad
+```
+
+**Follow-ups**
+- *Why is the ReLU backward pass just a mask?* Its derivative is 1 for positive inputs and 0 otherwise, so the incoming gradient is passed through or zeroed. (The derivative at exactly 0 is undefined; any convention works in practice.)
+- *Why He initialization here?* ReLU zeroes about half its inputs, halving the output variance per layer; the `2/fan_in` variance compensates so activations neither vanish nor explode with depth.
+- *Gradient check?* Compare the analytic gradient with `(L(w+ε) - L(w-ε)) / 2ε` for a few random coordinates; relative error below ~1e-7 means the backward pass is right.
+
+---
+
+## 11. Scaled Dot-Product Attention
+
+```python
+def scaled_dot_product_attention(Q, K, V, mask=None):
+    """Q: (..., n_q, d_k)  K: (..., n_k, d_k)  V: (..., n_k, d_v)"""
+    d_k = Q.shape[-1]
+    scores = Q @ np.swapaxes(K, -1, -2) / np.sqrt(d_k)      # (..., n_q, n_k)
+
+    if mask is not None:
+        scores = np.where(mask, scores, -np.inf)            # causal or padding mask
+
+    weights = softmax(scores, axis=-1)                      # (..., n_q, n_k)
+    return weights @ V, weights                             # (..., n_q, d_v)
+
+
+def causal_mask(n):
+    """Position i may attend only to positions <= i."""
+    return np.tril(np.ones((n, n), dtype=bool))
+```
+
+**Follow-ups**
+- *Why divide by `√d_k`?* If `q` and `k` have i.i.d. components with unit variance, their dot product has variance `d_k`. Without scaling, logits grow with dimension, softmax saturates into a near-one-hot distribution, and gradients vanish. The `√d_k` keeps the variance at 1.
+- *Complexity?* `O(n² · d)` time and `O(n²)` memory for the score matrix — the reason long context is expensive, and what FlashAttention addresses by never materializing that matrix.
+- *Multi-head?* Project to `h` sets of (Q,K,V) of dimension `d/h`, attend in parallel, concatenate, and apply an output projection. The point is letting different heads attend to different relationships.
+
+---
+
+## 12. Cosine Similarity Search
+
+```python
+def top_k_similar(query_vec, doc_matrix, k=5):
+    """query_vec: (d,)   doc_matrix: (n, d)"""
+    q = query_vec / (np.linalg.norm(query_vec) + 1e-12)
+    docs = doc_matrix / (np.linalg.norm(doc_matrix, axis=1, keepdims=True) + 1e-12)
+
+    sims = docs @ q                                   # (n, d) @ (d,) -> (n,)
+    idx = np.argpartition(-sims, kth=min(k, len(sims) - 1))[:k]
+    idx = idx[np.argsort(-sims[idx])]                 # sort only the k survivors
+    return idx, sims[idx]
+```
+
+**Follow-ups**
+- *Why is the epsilon there?* A zero vector (empty document, failed embedding) would divide by zero and produce NaNs that silently propagate through the ranking.
+- *Scaling past a few million vectors?* Exact search is `O(n·d)` per query. Move to an ANN index — HNSW for high recall at moderate memory, IVF-PQ for large corpora with tight memory budgets. Both trade a small recall loss for orders-of-magnitude speedup.
+
+---
+
+## 13. Text Chunking with Overlap
+
+A frequent practical question in AI engineering interviews.
+
+```python
+def chunk_text(text, chunk_size=500, overlap=50):
+    """Character-based chunking with overlap, respecting word boundaries."""
+    if overlap >= chunk_size:
+        raise ValueError("overlap must be smaller than chunk_size")
+
+    chunks, start = [], 0
+    while start < len(text):
+        end = min(start + chunk_size, len(text))
+
+        # Don't cut mid-word: back off to the last space, unless that loses too much
+        if end < len(text):
+            space = text.rfind(' ', start, end)
+            if space > start + chunk_size // 2:
+                end = space
+
+        chunk = text[start:end].strip()
+        if chunk:
+            chunks.append(chunk)
+
+        if end >= len(text):
+            break
+        start = end - overlap          # step forward, keeping `overlap` characters
+    return chunks
+```
+
+**Follow-ups**
+- *Why overlap at all?* An answer straddling a boundary would otherwise be split across two chunks and match neither query well. 10–20% overlap is the usual range.
+- *Why does the `end >= len(text)` break matter?* Without it, when `overlap` is large relative to the final chunk, `start` can fail to advance and the loop never terminates. Infinite-loop edge cases are exactly what interviewers probe.
+- *Better than character-based?* Token-based chunking matches what the model actually sees; structural splitting (headers, functions) preserves coherence better than either.
+
+---
+
+## 14. Rate Limiter with Exponential Backoff
+
+```python
+import time
+import random
+
+def call_with_backoff(fn, max_retries=5, base_delay=1.0, max_delay=60.0):
+    """Retry with exponential backoff and full jitter."""
+    for attempt in range(max_retries + 1):
+        try:
+            return fn()
+        except (RateLimitError, TransientError) as exc:
+            if attempt == max_retries:
+                raise
+            delay = min(base_delay * (2 ** attempt), max_delay)
+            time.sleep(random.uniform(0, delay))      # full jitter, not a fixed delay
+
+
+class TokenBucket:
+    """Allows bursts up to `capacity` while enforcing an average `rate` per second."""
+
+    def __init__(self, rate, capacity):
+        self.rate, self.capacity = rate, capacity
+        self.tokens = float(capacity)
+        self.last = time.monotonic()
+
+    def acquire(self, tokens=1):
+        now = time.monotonic()
+        self.tokens = min(self.capacity, self.tokens + (now - self.last) * self.rate)
+        self.last = now
+        if self.tokens >= tokens:
+            self.tokens -= tokens
+            return True
+        return False
+```
+
+**Follow-up**: *Why jitter?* Without it, every client that got rate-limited at the same moment retries at the same moment, producing a synchronized thundering herd that re-triggers the limit. Randomizing the delay spreads the retries out — this is why AWS's guidance is "full jitter", and it's a strong signal to mention it.
+
+---
+
+## 15. Reciprocal Rank Fusion
+
+Combining a keyword ranking and a vector ranking — the standard hybrid-search question.
+
+```python
+def reciprocal_rank_fusion(rankings, k=60):
+    """rankings: list of ranked doc-id lists, best first. Returns fused ids, best first."""
+    scores = {}
+    for ranking in rankings:
+        for rank, doc_id in enumerate(ranking, start=1):
+            scores[doc_id] = scores.get(doc_id, 0.0) + 1.0 / (k + rank)
+    return sorted(scores, key=scores.get, reverse=True)
+```
+
+**Follow-ups**
+- *Why fuse ranks instead of scores?* BM25 scores and cosine similarities live on incomparable scales, and normalizing them requires per-query calibration that is fragile. Ranks are unitless and directly comparable.
+- *What does `k=60` do?* It damps the influence of the very top ranks so a single system can't dominate the fusion. The value is empirical, from the original RRF paper, and is a reasonable default.
+
+---
+
+## Complexity Reference
+
+| Algorithm | Train | Predict (per sample) | Memory |
+|---|---|---|---|
+| Linear regression (closed form) | `O(nd² + d³)` | `O(d)` | `O(d²)` |
+| Linear/logistic regression (GD) | `O(nd)` per iteration | `O(d)` | `O(d)` |
+| KNN | `O(1)` (lazy) | `O(nd)` | `O(nd)` |
+| K-Means | `O(nkdi)` | `O(kd)` | `O(nd + kd)` |
+| Decision tree | `O(dn log n)` (sorted) | `O(depth)` | `O(nodes)` |
+| Random Forest | `O(T · dn log n)` | `O(T · depth)` | `O(T · nodes)` |
+| PCA (SVD) | `O(min(n²d, nd²))` | `O(dc)` | `O(nd)` |
+| Self-attention | `O(n²d)` | — | `O(n²)` |
+
+---
+
+## Common Pitfalls
+
+| Pitfall | Why it hurts | Fix |
+|---|---|---|
+| `exp()` without subtracting the max | Overflow → `inf` → NaN | `z - z.max(axis, keepdims=True)` |
+| `log(0)` in cross-entropy | `-inf` propagates through the loss | Add epsilon, or use the fused log-sum-exp form |
+| Broadcasting to an `(n, k, d)` tensor | Blows up memory on real data | Expand `‖a-b‖²` into matmuls |
+| `argsort` when you need top-k | `O(n log n)` instead of `O(n)` | `np.argpartition`, then sort the k survivors |
+| Forgetting to center before PCA | The first component points at the mean | Subtract the column means |
+| Regularizing the intercept | Biases predictions toward zero | Exclude index 0 from the penalty |
+| Not standardizing for distance-based models | Large-scale features dominate | Standardize for KNN, K-Means, SVM; not needed for trees |
+| Mutating an input array in place | Caller's data silently changes | Copy, or document it clearly |
+| Off-by-one in a chunking loop | Infinite loop or dropped tail | Explicit termination check on the final chunk |
+| Skipping shape comments | Shape bugs are the #1 failure mode | Annotate every matmul |
+
+---
+
+## Related Topics
+
+- [Python Coding Challenges](./python_coding_challenges.md)
+- [SQL Coding Challenges](./sql_coding_challenges.md)
+- [Model Evaluation and Metrics](../classical_ml/intro_model_evaluation.md)
+- [Ensemble Methods](../classical_ml/intro_ensemble_methods.md)
+- [Clustering](../classical_ml/intro_clustering.md)
+- [Dimensionality Reduction](../classical_ml/intro_dimensionality_reduction.md)
+- [Neural Network Training](../deep_learning/intro_neural_network_training.md)
+- [Transformers](../deep_learning/intro_transformers.md)

--- a/data_engineering/intro_data_engineering_for_ai.md
+++ b/data_engineering/intro_data_engineering_for_ai.md
@@ -116,6 +116,69 @@ feature-pipeline/
 
 ---
 
+## Interview Q&A
+
+#### What makes a data pipeline "reliable" beyond just running on schedule?
+
+Reliability means downstream consumers can trust the output without checking it. That requires: **idempotency** (re-running a task produces the same result, so retries and backfills are safe), **atomicity** (partial writes are never visible — write to a staging location and swap), **schema contracts** with validation at the boundary, **data quality checks** that fail the pipeline rather than publishing bad data, **freshness SLAs** that are monitored and alerted on, and **lineage** so you can answer "what does this table depend on and who breaks if it's wrong".
+
+The distinction worth drawing in an interview: a pipeline that succeeds while producing wrong data is worse than one that fails, because failure is visible and silent corruption is not. That's why quality checks belong in the pipeline as blocking gates, not in a dashboard someone might look at.
+
+#### How do you handle late-arriving and out-of-order data?
+
+Separate **event time** from **processing time** and key everything on event time. Then define a **watermark** — how late you're willing to wait — and a policy for what arrives after it: drop, route to a side output for reconciliation, or trigger a restatement of the affected window.
+
+For ML specifically, the consequence is that features must be computed **as-of** the event timestamp, not as-of now. A feature pipeline that joins current values onto historical labels leaks the future and is the most common source of "great offline, useless in production" models. Point-in-time correct joins are the fix, and they're what feature stores exist to provide.
+
+#### Batch or streaming — how do you decide?
+
+From the decision latency the business actually needs, not from what's fashionable. If a prediction made on yesterday's data is just as valuable, batch is dramatically cheaper to build, test, backfill, and operate. Streaming earns its complexity when freshness changes the outcome — fraud, real-time personalization, alerting, dynamic pricing.
+
+The honest answer includes the hybrid: most production systems batch-compute the expensive historical features and stream only the handful that genuinely need to be fresh, serving both through one interface. And it acknowledges the cost: streaming systems need exactly-once or idempotent semantics, watermarking, state management, and a replay story — none of which a nightly job needs.
+
+#### How do you version data for reproducible ML?
+
+Three layers, and interviewers want all three. **Immutable raw data** — append-only, partitioned by ingest date, never mutated. **Versioned table formats** (Delta Lake, Iceberg, Hudi) for the curated layer, which give you time travel, so "train on the data as of March 1" is a query rather than an archaeology project. **Snapshot references in the model artifact** — every training run records the exact table versions, feature definitions, and code commit used.
+
+Tools like DVC or LakeFS handle file-level versioning where table formats don't apply. The test of whether it works: can you reproduce a model trained six months ago, exactly, from its recorded metadata alone?
+
+#### What data quality checks would you put on an ML feature pipeline?
+
+Layered by cost and specificity:
+- **Schema**: expected columns, types, and nullability — catches upstream changes immediately.
+- **Volume**: row count within an expected range versus the same weekday historically — catches partial loads, which are the sneakiest failure.
+- **Freshness**: max timestamp within the SLA.
+- **Distribution**: null rate, cardinality, and summary statistics per column compared against a rolling baseline (PSI or a simple threshold) — catches semantic changes that pass schema checks.
+- **Referential**: joins produce the expected row count; no unexpected fan-out from a duplicated key.
+- **Business rules**: domain invariants — amounts non-negative, timestamps ordered, statuses in a known set.
+
+Blocking versus alerting matters: schema and volume failures should stop the pipeline; distribution shifts should page someone, because they may be legitimate.
+
+#### How do you prevent training/serving skew?
+
+The structural answer is a single feature definition used by both paths, which is what a feature store provides — the same transformation code computes offline training features and online serving features, so they cannot diverge.
+
+Without one: put transformations inside the model artifact (a pipeline object) rather than in notebook preprocessing; log the actual features used at serving time and periodically compare their distribution to the training set; and add an integration test that scores the same entity through both paths and asserts the feature vectors match. That last test is cheap and catches the majority of skew bugs before release.
+
+---
+
+## Common Pitfalls
+
+| Pitfall | Why it hurts | Fix |
+|---|---|---|
+| Non-idempotent pipeline tasks | Retries and backfills duplicate or corrupt data | Deterministic partitioning; overwrite-by-partition, not append |
+| Publishing partial writes | Consumers read half-loaded data | Write to staging, then atomic swap or table-format commit |
+| Joining current feature values onto historical labels | Label leakage; offline scores are unreachable in production | Point-in-time correct joins on event time |
+| Quality checks as dashboards, not gates | Bad data reaches consumers and nobody notices | Blocking assertions in the pipeline |
+| Row-count checks against a fixed threshold | Weekly seasonality causes constant false alarms | Compare against the same weekday historically |
+| Mutating raw data in place | Reproducibility is gone permanently | Append-only raw layer; transform into a curated layer |
+| Streaming chosen by default | Large complexity cost for latency nobody needed | Start batch; stream only the features that need freshness |
+| Separate transformation code for training and serving | Guaranteed skew over time | One shared definition, or a feature store |
+| No lineage | Impact of a schema change is unknowable | Lineage tracking (dbt, OpenLineage, catalog integration) |
+| Ignoring late data entirely | Silent undercounting in every window | Explicit watermark and a late-arrival policy |
+
+---
+
 ## Related Topics
 
 - [Data Modeling](./data-modeling.md)

--- a/deep_learning/intro_applied_deep_learning.md
+++ b/deep_learning/intro_applied_deep_learning.md
@@ -178,6 +178,67 @@ image-classifier/
 
 ---
 
+## Interview Q&A
+
+#### How do you decide between training from scratch, fine-tuning, and using a pretrained model as-is?
+
+Work down from cheapest. **Pretrained as-is (or with a frozen backbone + new head)** whenever the pretraining domain is close to yours and you have a few thousand labeled examples or fewer — this covers most real problems. **Fine-tuning** when you have enough labeled data (typically tens of thousands of examples) or when the domain differs meaningfully from the pretraining distribution — medical imaging, satellite imagery, industrial defect detection. **From scratch** almost never: only when the input modality has no relevant pretrained model at all, or when you have millions of labeled examples and a research budget.
+
+The related decision is *how much* to fine-tune: freezing early layers and training later ones is the standard middle ground, since early layers learn general features (edges, textures) and later layers learn task-specific ones. With very little data, freezing more prevents overfitting.
+
+#### Your model gets 95% training accuracy and 65% validation accuracy. What do you do?
+
+Confirm the gap is real before treating it. Check that the validation set isn't distributionally different (different source, different preprocessing, different time period) and that validation-time augmentation isn't applied — those look like overfitting and aren't.
+
+If it's genuine overfitting, in order of expected impact: **more data or stronger augmentation** (almost always the biggest win in vision), **early stopping** on validation loss, **more regularization** (weight decay, dropout, label smoothing), **a smaller or more constrained model**, and **transfer learning with more layers frozen** if you're training too much capacity for the data available.
+
+If the training accuracy itself is suspicious, check for leakage — duplicate or near-duplicate images across the split is extremely common in scraped datasets and inflates training metrics specifically.
+
+#### How do you structure a training pipeline that others can reproduce?
+
+Configuration-driven rather than notebook-driven: one config file holding data paths, hyperparameters, and seeds; a deterministic data pipeline with a fixed, versioned split; seeded random number generators for Python, NumPy, and the framework; and an experiment tracker (MLflow, Weights & Biases) recording config, metrics, the code commit, the data version, and the resulting artifact.
+
+Checkpointing matters more than people expect: save on every improvement with the optimizer and scheduler state included, so a run can resume rather than restart. And separate the pipeline into stages — data prep, train, evaluate, export — so a failure in one doesn't cost the others.
+
+Full determinism on GPU costs speed (deterministic kernels, no cuDNN autotuning), so the practical standard is seeded and versioned, with a note that exact bitwise reproduction requires the deterministic flags.
+
+#### How do you choose a batch size and learning rate together?
+
+Pick the largest batch that fits in memory and trains stably, then set the learning rate using the linear scaling rule: relative to a known-good configuration, scaling the batch by `k` means scaling the LR by roughly `k`, with warmup. Verify with a short LR range test — increase the LR exponentially over a few hundred steps and take roughly an order of magnitude below where the loss diverges.
+
+Two caveats worth raising: beyond a task-dependent critical batch size, larger batches stop improving the gradient estimate and you're spending compute for nothing; and small batches inject gradient noise that often generalizes slightly better, so the largest possible batch is not automatically the best batch.
+
+#### How do you speed up a training run that's taking too long?
+
+Profile first — most "slow training" is a starved GPU, not a slow model. Check GPU utilization: if it's below 80%, the bottleneck is data loading, and the fixes are more `num_workers`, `pin_memory=True`, `persistent_workers=True`, pre-decoded or pre-tokenized data, and removing synchronization points like `.item()` inside the loop.
+
+Once the GPU is saturated: mixed precision (bf16) for a near-free 1.5–2x, larger batches, `torch.compile` for kernel fusion, and gradient accumulation only if you need a larger effective batch. Then algorithmic wins — a smaller model that meets the requirement, fewer epochs with early stopping, or a subset of the data for hyperparameter search before the full run. Distributed training is the last resort because it adds the most complexity per unit of speedup.
+
+#### What do you monitor during a long training run?
+
+Training and validation loss on the same axis (divergence tells you when to stop), learning rate (to confirm the schedule is doing what you think), gradient norm (spikes precede divergence and justify clipping), GPU utilization and memory, and throughput in samples per second so you notice a slowdown.
+
+For anything beyond a short run, add automatic alerting on NaN loss and on validation loss failing to improve for N evaluations, plus periodic checkpointing — discovering at hour 40 that the run diverged at hour 3 is an avoidable and expensive mistake.
+
+---
+
+## Common Pitfalls
+
+| Pitfall | Why it hurts | Fix |
+|---|---|---|
+| Not verifying the model can overfit one batch | Hours of tuning spent on a code bug | Overfit a single batch to near-zero loss first |
+| Augmentation applied to the validation set | Validation loss becomes noise, not signal | Separate train and eval transform pipelines |
+| Duplicate or near-duplicate images across splits | Inflated metrics; the model memorized | Deduplicate by perceptual hash before splitting |
+| Forgetting `model.eval()` at inference | Dropout on and BatchNorm using batch statistics | `model.eval()` + `torch.no_grad()` |
+| Tuning hyperparameters on the test set | Reported performance is optimistic | Separate validation and test sets |
+| Checkpointing weights without optimizer state | A resumed run restarts the optimizer cold | Save model, optimizer, scheduler, epoch, and RNG state |
+| Notebook-only training | Not reproducible, not reviewable, not schedulable | Config-driven scripts with experiment tracking |
+| Ignoring GPU utilization | Runs take 3x longer than necessary | Profile; fix data loading before touching the model |
+| No early stopping on a long run | Wasted compute past the best checkpoint | Early stopping on validation, plus alerting |
+| Class imbalance ignored in the loss | The model collapses to the majority class | Class weights, focal loss, or balanced sampling |
+
+---
+
 ## Related Topics
 
 - [Deep Learning Overview](./README.md)

--- a/deep_learning/intro_neural_network_training.md
+++ b/deep_learning/intro_neural_network_training.md
@@ -1,0 +1,394 @@
+# Neural Network Training: Optimization and Regularization
+
+Architecture gets the headlines; training dynamics decide whether the model works. This guide covers what interviewers actually probe when they ask "your loss is NaN, what now?" — initialization, optimizers, learning rate schedules, normalization, regularization, and the debugging playbook for a model that won't converge.
+
+---
+
+## Table of Contents
+1. [Backpropagation and the Gradient Problems](#backpropagation-and-the-gradient-problems)
+2. [Weight Initialization](#weight-initialization)
+3. [Activation Functions](#activation-functions)
+4. [Optimizers](#optimizers)
+5. [Learning Rate Schedules](#learning-rate-schedules)
+6. [Normalization Layers](#normalization-layers)
+7. [Regularization](#regularization)
+8. [Batch Size and Its Effects](#batch-size-and-its-effects)
+9. [Mixed Precision and Memory](#mixed-precision-and-memory)
+10. [A Debugging Playbook](#a-debugging-playbook)
+11. [Interview Q&A](#interview-qa)
+12. [Common Pitfalls](#common-pitfalls)
+13. [Related Topics](#related-topics)
+
+---
+
+## Backpropagation and the Gradient Problems
+
+Backprop is the chain rule applied over a computation graph. For an `L`-layer network the gradient at layer 1 contains a product of `L` Jacobians:
+
+```
+∂Loss/∂W₁ = ∂Loss/∂aL · ∂aL/∂a(L-1) · ... · ∂a2/∂a1 · ∂a1/∂W₁
+```
+
+Products of many terms are unstable:
+
+| Problem | Cause | Symptom | Fix |
+|---|---|---|---|
+| **Vanishing gradients** | Jacobian norms < 1 compound toward 0 | Early layers stop learning; loss plateaus high | ReLU-family activations, residual connections, normalization, careful init, LSTM/GRU gates |
+| **Exploding gradients** | Jacobian norms > 1 compound upward | Loss spikes to NaN/Inf; weights blow up | Gradient clipping, lower LR, normalization, better init |
+
+Residual connections are the most important structural fix: `y = x + F(x)` gives the gradient an identity path (`∂y/∂x = I + ∂F/∂x`), so gradients reach early layers even when `F`'s Jacobian is small. This is why 100+ layer networks became trainable at all.
+
+```python
+torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)  # after backward(), before step()
+```
+
+---
+
+## Weight Initialization
+
+Initialization sets the scale of activations and gradients at step 0. Get it wrong and the network is dead or diverging before training starts.
+
+| Scheme | Variance | Use with |
+|---|---|---|
+| **Xavier / Glorot** | `2 / (fan_in + fan_out)` | tanh, sigmoid, linear |
+| **He / Kaiming** | `2 / fan_in` | ReLU, LeakyReLU, GELU |
+| **LeCun** | `1 / fan_in` | SELU |
+| **Orthogonal** | orthogonal matrix | RNNs, where repeated multiplication needs norm preservation |
+
+He initialization uses `2/fan_in` rather than `1/fan_in` because ReLU zeroes roughly half its inputs, halving the output variance; the factor of 2 compensates.
+
+```python
+import torch.nn as nn
+
+def init_weights(m):
+    if isinstance(m, nn.Linear):
+        nn.init.kaiming_normal_(m.weight, nonlinearity='relu')
+        if m.bias is not None:
+            nn.init.zeros_(m.bias)
+
+model.apply(init_weights)
+```
+
+Never initialize all weights to the same constant: every neuron in a layer would receive identical gradients and stay identical forever (the symmetry-breaking problem). Zero-initializing *biases* is fine and standard.
+
+---
+
+## Activation Functions
+
+| Activation | Formula | Pros | Cons |
+|---|---|---|---|
+| Sigmoid | `1/(1+e^-x)` | Bounded, probabilistic reading | Saturates → vanishing gradient; not zero-centered |
+| Tanh | `(e^x - e^-x)/(e^x + e^-x)` | Zero-centered | Still saturates |
+| **ReLU** | `max(0, x)` | Cheap, no positive saturation, sparse | Dying ReLU; not zero-centered |
+| LeakyReLU | `max(αx, x)` | No dead units | Extra hyperparameter |
+| **GELU** | `x · Φ(x)` | Smooth, strong in transformers | Slightly more expensive |
+| **SiLU/Swish** | `x · σ(x)` | Smooth, strong empirically | Same |
+| Softmax | normalized exponentials | Output distribution | Output layer only |
+
+**Dying ReLU**: a unit whose pre-activation is negative for every input outputs 0 and receives zero gradient forever — permanently dead. Usually caused by too-high a learning rate driving a large negative bias. LeakyReLU, GELU, or lowering the LR all fix it.
+
+Modern transformers use GELU or SwiGLU; the smoothness near zero gives slightly better gradients than ReLU's kink and empirically improves language-model quality at the same parameter count.
+
+---
+
+## Optimizers
+
+| Optimizer | Update rule (essence) | Strengths | Weaknesses |
+|---|---|---|---|
+| **SGD** | `w ← w - η∇` | Simple; often best final accuracy in vision | Slow; LR-sensitive |
+| **SGD + momentum** | `v ← βv + ∇; w ← w - ηv` | Dampens oscillation, escapes plateaus | Two hyperparameters |
+| **RMSProp** | Per-parameter scaling by RMS of gradients | Handles varying gradient scales | No momentum |
+| **Adam** | Momentum + RMSProp + bias correction | Fast, robust defaults | Can generalize worse than SGD; weight decay is wrong |
+| **AdamW** | Adam with **decoupled** weight decay | The default for transformers | — |
+| **Adafactor / 8-bit Adam** | Factored or quantized optimizer state | Large memory savings at scale | Slight quality cost |
+
+### Adam, precisely
+
+```
+m_t = β₁ m_{t-1} + (1-β₁) g_t            # first moment (momentum)
+v_t = β₂ v_{t-1} + (1-β₂) g_t²           # second moment (per-parameter scale)
+m̂_t = m_t/(1-β₁^t),  v̂_t = v_t/(1-β₂^t)  # bias correction — m,v start at 0
+w_t = w_{t-1} - η · m̂_t / (√v̂_t + ε)
+```
+
+Bias correction matters most in the first few hundred steps: without it, `m` and `v` are biased toward zero, making early effective steps far too small.
+
+### Why AdamW instead of Adam
+
+In Adam, L2 regularization added to the loss gets divided by `√v̂`, so parameters with large historical gradients get *less* decay — the opposite of the intent. AdamW decouples it:
+
+```
+w ← w - η(m̂/(√v̂ + ε) + λw)     # decay applied directly to the weight
+```
+
+This is not a minor detail; it is why AdamW is the standard for transformer training. Typical settings: `lr=1e-4` to `3e-4` for transformers from scratch, `1e-5` to `5e-5` for fine-tuning, `betas=(0.9, 0.95)` for large language models (lower `β₂` than the 0.999 default responds faster to loss spikes), `weight_decay=0.1`, and **no weight decay on biases or LayerNorm parameters**.
+
+```python
+decay, no_decay = [], []
+for name, param in model.named_parameters():
+    if not param.requires_grad:
+        continue
+    if param.ndim < 2 or 'bias' in name or 'norm' in name.lower():
+        no_decay.append(param)      # biases and norm scales: no decay
+    else:
+        decay.append(param)
+
+optimizer = torch.optim.AdamW(
+    [{'params': decay, 'weight_decay': 0.1},
+     {'params': no_decay, 'weight_decay': 0.0}],
+    lr=3e-4, betas=(0.9, 0.95), eps=1e-8,
+)
+```
+
+**Memory cost**: Adam stores two extra float32 tensors per parameter. A 7B model needs ~14 GB for fp16 weights plus ~56 GB for fp32 master weights, gradients, and optimizer state — which is why full fine-tuning of a 7B model does not fit on a 24 GB GPU and LoRA does.
+
+---
+
+## Learning Rate Schedules
+
+The learning rate is the single most important hyperparameter. Tune it first, and by orders of magnitude (1e-5, 1e-4, 1e-3), not by 10%.
+
+| Schedule | Shape | Use |
+|---|---|---|
+| **Linear warmup** | 0 → peak over N steps | Essential for transformers; Adam's variance estimate is unreliable early |
+| **Cosine decay** | Peak → ~0 on a cosine curve | Default for LLM pretraining and fine-tuning |
+| **Step decay** | Drop by 10x at milestones | Classic vision recipes |
+| **ReduceLROnPlateau** | Drop when validation stalls | When you can't predict the schedule |
+| **One-cycle** | Up then down, with momentum inverted | Fast convergence on small budgets |
+
+```python
+from torch.optim.lr_scheduler import LambdaLR
+import math
+
+def cosine_with_warmup(optimizer, warmup_steps, total_steps, min_ratio=0.1):
+    def lr_lambda(step):
+        if step < warmup_steps:
+            return step / max(1, warmup_steps)
+        progress = (step - warmup_steps) / max(1, total_steps - warmup_steps)
+        return min_ratio + (1 - min_ratio) * 0.5 * (1 + math.cos(math.pi * progress))
+    return LambdaLR(optimizer, lr_lambda)
+
+scheduler = cosine_with_warmup(optimizer, warmup_steps=500, total_steps=20_000)
+# step the scheduler every optimizer step, not every epoch
+```
+
+**Why warmup?** At step 0, Adam's second-moment estimate `v` is based on almost no data and is noisy. Large early steps in a random direction can push the model into a bad region it never escapes. Warmup also matters more with large batches, where each step is more confident and therefore more damaging if wrong.
+
+**Finding the LR empirically**: run an LR range test — increase the LR exponentially over a few hundred steps and plot loss. Pick roughly an order of magnitude below where the loss starts diverging.
+
+---
+
+## Normalization Layers
+
+| Layer | Normalizes over | Batch dependence | Typical use |
+|---|---|---|---|
+| **BatchNorm** | Batch dimension, per channel | Yes — different train/eval behavior | CNNs |
+| **LayerNorm** | Feature dimension, per sample | No | Transformers, RNNs |
+| **RMSNorm** | Feature dimension, no mean subtraction | No | Modern LLMs (Llama, Mistral) — cheaper |
+| **GroupNorm** | Groups of channels | No | Small-batch vision, segmentation |
+| **InstanceNorm** | Per sample, per channel | No | Style transfer |
+
+**Why transformers use LayerNorm, not BatchNorm**: sequences have variable length, so batch statistics are computed over a ragged, padded tensor and become noisy and length-dependent. LayerNorm normalizes within one token's feature vector, so it behaves identically for batch size 1 and batch size 512 — critical when training and inference batch sizes differ wildly.
+
+**BatchNorm's train/eval trap**: at training time it uses batch statistics; at eval it uses running averages. Forgetting `model.eval()` at inference means predictions depend on whatever else is in the batch — a genuinely common production bug that also breaks batch-size-1 serving.
+
+**Pre-norm vs post-norm**: the original transformer applied LayerNorm after the residual add (post-norm), which needs careful warmup to train deeply. Modern models use pre-norm (`x + Attention(LN(x))`), which keeps a clean identity path through the residual stream and trains stably at depth. Pre-norm is why you can train a 70-layer transformer without an elaborate warmup schedule.
+
+---
+
+## Regularization
+
+| Technique | Mechanism | Notes |
+|---|---|---|
+| **L2 / weight decay** | Penalizes large weights | Use AdamW's decoupled form; exclude biases and norms |
+| **L1** | Penalizes absolute weights | Induces sparsity; rare in deep nets |
+| **Dropout** | Randomly zeroes activations, scales the rest | `p=0.1` in transformers, `0.5` in old MLP heads |
+| **Early stopping** | Halts at best validation | Effectively limits capacity; always worth it |
+| **Data augmentation** | Expands the effective dataset | Usually the highest-leverage option |
+| **Label smoothing** | Target `1-ε` instead of `1` | Reduces overconfidence, improves calibration |
+| **Stochastic depth** | Randomly skips residual blocks | Very deep vision networks |
+| **Mixup / CutMix** | Trains on convex combinations of examples | Strong vision regularizer |
+| **Gradient noise / EMA of weights** | Smooths the optimization path | EMA is nearly free and often helps |
+
+**Dropout's inverted scaling**: at train time, surviving activations are divided by `(1-p)` so the expected value matches inference, where dropout is off. This is why `model.eval()` is required — without it you keep dropping units at inference and get noisy, degraded predictions.
+
+Dropout and BatchNorm interact badly (dropout changes the variance BatchNorm estimated), which is part of why modern architectures use much less dropout than 2015-era networks and rely on weight decay, augmentation, and scale instead.
+
+---
+
+## Batch Size and Its Effects
+
+| Batch size | Gradient noise | Steps/epoch | Generalization | Hardware use |
+|---|---|---|---|---|
+| Small (8–64) | High | Many | Often better (noise regularizes) | Underutilized GPU |
+| Large (1k–8k+) | Low | Few | Needs LR scaling and warmup | Efficient |
+
+The **linear scaling rule**: multiply the batch size by `k`, multiply the learning rate by `k` (with warmup). It holds well up to a point and then breaks — beyond a critical batch size, extra examples per step stop improving the gradient estimate and you're just burning compute.
+
+**Gradient accumulation** simulates a large batch on small hardware:
+
+```python
+accum_steps = 8
+optimizer.zero_grad(set_to_none=True)
+for i, batch in enumerate(loader):
+    with torch.autocast('cuda', dtype=torch.bfloat16):
+        loss = model(**batch).loss / accum_steps       # divide to keep the gradient scale right
+    loss.backward()
+    if (i + 1) % accum_steps == 0:
+        torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)
+        optimizer.step()
+        scheduler.step()
+        optimizer.zero_grad(set_to_none=True)
+```
+
+Note the `/ accum_steps`: forgetting it makes the effective gradient `accum_steps` times too large, which usually presents as a mysterious divergence after switching to accumulation.
+
+---
+
+## Mixed Precision and Memory
+
+| Format | Bits | Range | Notes |
+|---|---|---|---|
+| fp32 | 32 | Wide | Baseline, 4 bytes/param |
+| **fp16** | 16 | Narrow | 2x faster, needs loss scaling to avoid gradient underflow |
+| **bf16** | 16 | Same exponent range as fp32 | Preferred on A100/H100 — no loss scaling needed |
+| fp8 | 8 | Very narrow | H100+ training, still specialized |
+
+```python
+# bf16 — the modern default where supported
+with torch.autocast('cuda', dtype=torch.bfloat16):
+    loss = model(**batch).loss
+loss.backward()
+
+# fp16 requires a GradScaler because small gradients underflow to zero
+scaler = torch.amp.GradScaler()
+with torch.autocast('cuda', dtype=torch.float16):
+    loss = model(**batch).loss
+scaler.scale(loss).backward()
+scaler.unscale_(optimizer)
+torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)
+scaler.step(optimizer)
+scaler.update()
+```
+
+**Where training memory goes** (per parameter, mixed-precision AdamW): 2 bytes fp16 weights + 4 bytes fp32 master weights + 4 bytes gradients + 8 bytes optimizer state ≈ **18 bytes/param**, before activations. Activations often dominate and scale with `batch × sequence_length × hidden × layers`.
+
+Levers when you hit OOM, in order of cost to quality: reduce batch size with gradient accumulation (free), gradient checkpointing (recompute activations — ~30% slower, big memory win), bf16 (free on modern GPUs), 8-bit optimizer states, LoRA/QLoRA instead of full fine-tuning, then model/tensor parallelism.
+
+---
+
+## A Debugging Playbook
+
+**Loss is NaN.**
+Check in this order: learning rate too high (most common); fp16 overflow (switch to bf16 or add loss scaling); division by zero or `log(0)` in a custom loss (add epsilon); a corrupt batch with NaN inputs; missing gradient clipping. Bisect by running with `torch.autograd.set_detect_anomaly(True)` to find the offending op.
+
+**Loss doesn't decrease at all.**
+First: can the model overfit a single batch to near-zero loss? If not, the bug is in the code, not the hyperparameters — check that the optimizer sees the parameters, that `loss.backward()` is called, that `zero_grad()` isn't clearing after backward, that labels align with inputs, and that the LR isn't ~0.
+
+**Training loss falls, validation loss rises.**
+Standard overfitting: more data or augmentation, more regularization, smaller model, early stopping. If validation loss rises from the very first epoch, suspect a train/validation distribution mismatch or a broken validation transform instead.
+
+**Training loss is much worse than validation loss.**
+Usually dropout/BatchNorm accounting (training loss includes regularization noise; eval doesn't) — normal early on. If persistent, the validation set may be easier or leaking.
+
+**Loss spikes mid-training.**
+Common in LLM training: reduce `β₂` to 0.95, clip gradients harder, skip the batch, or resume from the last checkpoint with a lower LR. Repeated spikes at the same data offset means a bad shard.
+
+**GPU utilization is low.**
+Data loading is the bottleneck: raise `num_workers`, enable `pin_memory=True` and `persistent_workers=True`, pre-tokenize offline, and check you aren't synchronizing with `.item()` or `.cpu()` inside the loop.
+
+---
+
+## Interview Q&A
+
+#### Explain vanishing gradients and three ways to fix them.
+
+In a deep network, the gradient at an early layer is a product of many Jacobians. When those factors have norm below 1 — as with saturated sigmoid or tanh units, whose derivative maxes at 0.25 — the product shrinks exponentially with depth, and early layers receive effectively no learning signal.
+
+Fixes: (1) **ReLU-family activations**, whose derivative is exactly 1 on the positive side, so no shrinkage per layer; (2) **residual connections**, which add an identity path so the gradient reaches early layers regardless of what the block does; (3) **normalization layers**, which keep activation scales stable across depth so Jacobians stay near unit norm. Careful initialization (He/Xavier) and, for RNNs specifically, gated architectures (LSTM/GRU) with additive cell-state updates are the other standard answers.
+
+#### Adam vs SGD with momentum — which do you pick?
+
+AdamW for transformers and anything with sparse or badly scaled gradients; it adapts per-parameter step sizes and works near-default, which matters when a training run costs real money. SGD with momentum for convolutional vision models trained long, where it still often reaches a better final test accuracy — the usual explanation is that its noisier, non-adaptive updates favor flatter minima.
+
+I'd note that the comparison is often unfair: Adam works well with almost no tuning, while SGD needs a well-tuned LR and schedule to show its advantage. If tuning budget is small, Adam wins by default.
+
+#### Why do transformers need learning rate warmup?
+
+Two reasons. First, Adam's second-moment estimate is computed from very few samples at the start, so the per-parameter scaling is unreliable and early updates can be wildly wrong in magnitude. Warmup keeps steps small until the estimate stabilizes. Second, with post-norm architectures the residual path is poorly conditioned early in training, and large steps push the model into a region it doesn't recover from. Pre-norm architectures need less warmup, which is one reason they became standard, but warmup still helps at large batch sizes where each step is taken with high confidence.
+
+#### What is the difference between BatchNorm and LayerNorm, and why do transformers use LayerNorm?
+
+BatchNorm normalizes each feature across the batch dimension; LayerNorm normalizes each sample across its feature dimension. The consequence is that BatchNorm's output for one example depends on the other examples in the batch, and it must maintain running statistics for a separate inference-time behavior.
+
+Transformers use LayerNorm because sequences are variable-length and padded, making batch statistics noisy and length-dependent; because inference often runs at batch size 1 where batch statistics are meaningless; and because it removes the train/eval discrepancy entirely. Modern LLMs go further to RMSNorm, dropping the mean-subtraction step for a small speedup with no measured quality loss.
+
+#### Your training loss goes to NaN after 200 steps. Walk me through the diagnosis.
+
+I'd bisect systematically rather than guess. First reproduce deterministically with a fixed seed and find the exact step. Then:
+1. **Lower the LR by 10x** — if it survives, the LR was too high. This is the most common cause by a wide margin.
+2. **Check precision** — in fp16, activations or gradients can overflow; switching to bf16 (same exponent range as fp32) rules this in or out immediately.
+3. **Inspect the batch at the failure step** — NaNs or infinities in the inputs, or an empty/degenerate label.
+4. **Check the loss for `log(0)` or division by zero**, especially in custom losses; add epsilon.
+5. **Add gradient clipping** at norm 1.0 and log the pre-clip gradient norm — a spike right before the NaN confirms exploding gradients.
+
+If none of that fixes it, `torch.autograd.set_detect_anomaly(True)` will name the operation that first produced a NaN in the backward pass.
+
+#### How do you train a model that doesn't fit in GPU memory?
+
+Escalating in order of cost:
+1. **Gradient accumulation** — small micro-batches with the same effective batch size; free.
+2. **Mixed precision (bf16)** — halves weight and activation memory, usually faster too.
+3. **Gradient checkpointing** — store only some activations and recompute the rest in the backward pass; roughly 30% slower for a large memory saving.
+4. **8-bit optimizer states** (bitsandbytes) — cuts the 8 bytes/param of Adam state to 2.
+5. **Parameter-efficient fine-tuning (LoRA/QLoRA)** — train small adapter matrices while the base model stays frozen and quantized; this is what makes 7B–70B fine-tuning possible on consumer GPUs.
+6. **Sharding across GPUs** — ZeRO/FSDP partitions optimizer state, gradients, then parameters; tensor and pipeline parallelism for models too large for one device even at inference.
+
+#### What does weight decay actually do, and why exclude biases from it?
+
+Weight decay shrinks weights toward zero each step, penalizing large-magnitude parameters and favoring simpler functions. In AdamW it is applied directly to the weight rather than through the loss, so the adaptive denominator doesn't distort it.
+
+Biases and normalization scale parameters are excluded because they don't contribute to model complexity in the same way — a bias just shifts the activation, and decaying LayerNorm's gain toward zero actively fights the normalization it's supposed to perform. Decaying them typically costs a little accuracy for no regularization benefit.
+
+#### How does batch size interact with learning rate?
+
+Larger batches give lower-variance gradient estimates, so you can safely take larger steps. The linear scaling rule (`k×` batch → `k×` LR, with warmup) captures this and works well up to a critical batch size that depends on the task. Beyond it, gradient noise is already negligible and further increases buy no convergence speedup per example — you're paying compute for nothing.
+
+Small batches inject noise that acts as a regularizer and often generalizes slightly better; large batches are hardware-efficient. In practice I'd pick the largest batch that fits and trains stably, then tune the LR around the scaling rule's prediction.
+
+#### What is gradient checkpointing and what does it cost?
+
+During the forward pass, activations are normally kept for the backward pass, and they often dominate memory. Gradient checkpointing stores activations only at chosen boundaries and recomputes the intermediate ones during backward. Memory for activations drops from `O(n)` to roughly `O(√n)` with optimal placement; the cost is one extra forward pass through the checkpointed segments, typically 25–40% slower wall-clock. It's the standard first move when you want a larger batch or longer sequences and are activation-bound rather than parameter-bound.
+
+#### Why is bf16 usually preferred over fp16 for training?
+
+bf16 has the same 8-bit exponent as fp32, so it covers the same dynamic range with less mantissa precision. fp16 has a much narrower range, so small gradients underflow to zero and large activations overflow to infinity — which is why fp16 training requires a `GradScaler` that multiplies the loss, checks for infinities, and adapts the scale. bf16 needs none of that machinery and just works, at the cost of ~3 fewer mantissa bits that neural network training turns out not to need. On hardware that supports both (A100 and later), bf16 is the default.
+
+---
+
+## Common Pitfalls
+
+| Pitfall | Why it hurts | Fix |
+|---|---|---|
+| Forgetting `model.eval()` at inference | Dropout stays on and BatchNorm uses batch stats — predictions depend on batch contents | `model.eval()` + `torch.no_grad()` |
+| `zero_grad()` after `backward()` | Wipes the gradients you just computed | Zero at the start of the step |
+| Not dividing loss by accumulation steps | Effective gradient is `k×` too large | `loss = loss / accum_steps` |
+| Stepping the scheduler per epoch when it expects steps | LR decays far too slowly | Match the scheduler's assumed unit |
+| Weight decay on biases and LayerNorm | Fights normalization, costs accuracy | Parameter groups with `weight_decay=0` for those |
+| Tuning LR in 10% increments | The useful range spans orders of magnitude | Search 1e-5 / 1e-4 / 1e-3, then refine |
+| No gradient clipping on transformers | A single bad batch NaNs the run | `clip_grad_norm_(..., 1.0)` |
+| Validating with training-time augmentation | Validation loss is noise, not signal | Separate eval transform pipeline |
+| Not checking you can overfit one batch | Hours spent tuning a model with a code bug | Overfit 1 batch to ~0 loss before any real run |
+| Data loader starving the GPU | 20% utilization, 5x longer runs | More workers, `pin_memory`, pre-tokenize |
+
+---
+
+## Related Topics
+
+- [Applied Deep Learning Roadmap](./intro_applied_deep_learning.md)
+- [Transformers](./intro_transformers.md)
+- [Fine-Tuning](./intro_fine_tuning.md)
+- [Computer Vision](./intro_computer_vision.md)
+- [PyTorch](../frameworks/intro_pytorch.md)
+- [LLM Inference Optimization](../ai_genai/intro_llm_inference_optimization.md)
+- [Deep Learning Overview](./README.md)

--- a/docs/2026-interview-roadmap.md
+++ b/docs/2026-interview-roadmap.md
@@ -1,12 +1,187 @@
 # 2026 Interview Roadmap
 
-For 2026 Machine Learning Engineer and AI Engineer interviews, the most common evaluation areas are:
+A plan, not a reading list. This page tells you **what is being tested in 2026**, **which topics matter for your specific role**, and **what to study in what order given how much time you have**.
 
-* Classical machine learning fundamentals: bias vs variance, metrics, feature engineering, regularization, cross-validation.
-* Deep learning fundamentals: optimization, architectures, embeddings, transfer learning, sequence modeling.
-* LLM application engineering: prompting, tool use, RAG, vector search, grounding, context management.
-* Workflow automation and orchestration: know when to use n8n, LangGraph, Airflow, or custom services for AI-enabled systems.
-* Evaluation: offline metrics, online metrics, human review, hallucination detection, regression testing.
-* MLOps and production ML: deployment, monitoring, data drift, experiment tracking, CI/CD, rollback strategy.
-* System design: latency, throughput, cost, reliability, observability, caching, batching, and failure modes.
-* Responsible AI: safety, prompt injection risk, privacy, access control, bias, governance, and model misuse prevention.
+---
+
+## Table of Contents
+1. [What Changed for 2026](#what-changed-for-2026)
+2. [Core Evaluation Areas](#core-evaluation-areas)
+3. [Role-by-Role Focus Matrix](#role-by-role-focus-matrix)
+4. [The Typical Interview Loop](#the-typical-interview-loop)
+5. [Study Plans by Time Available](#study-plans-by-time-available)
+6. [Depth Checklist](#depth-checklist)
+7. [The Week Before](#the-week-before)
+8. [Related Topics](#related-topics)
+
+---
+
+## What Changed for 2026
+
+The classical ML fundamentals have not moved — bias/variance, metrics, regularization, and validation are still asked in nearly every loop. What changed is the layer on top.
+
+| Shift | What it means for interviews |
+|---|---|
+| **From "can you train a model" to "can you ship a system"** | Expect production, monitoring, and cost questions even in "modeling" rounds |
+| **Agents are the default architecture** | Tool use, planning loops, failure handling, and cost control are standard questions |
+| **RAG is assumed, not impressive** | You'll be asked why your retrieval *failed*, not what RAG is |
+| **Evaluation is the differentiator** | "How do you know it works?" is now the hardest question in most loops |
+| **Inference economics are interview material** | KV cache, batching, quantization, and cost-per-request appear in AI Engineer loops |
+| **Context engineering replaced prompt tricks** | Structuring what the model sees, not clever phrasing |
+| **Security is a real round** | Prompt injection, tool permissions, data exfiltration through agents |
+
+The single most common reason strong candidates fail an AI Engineer loop in 2026: they can build the happy path and cannot answer how they'd *evaluate* it, *monitor* it, or *bound its cost*.
+
+---
+
+## Core Evaluation Areas
+
+Every loop draws from these eight. The weight shifts by role, but none is safe to skip entirely.
+
+| # | Area | Sample of what's tested | Start here |
+|---|---|---|---|
+| 1 | **Classical ML fundamentals** | Bias/variance, regularization, cross-validation, imbalanced data, leakage | [Classical ML](../classical_ml/README.md), [Model Evaluation](../classical_ml/intro_model_evaluation.md), [Ensembles](../classical_ml/intro_ensemble_methods.md) |
+| 2 | **Deep learning fundamentals** | Optimizers, normalization, attention, transfer learning, training failures | [Transformers](../deep_learning/intro_transformers.md), [NN Training](../deep_learning/intro_neural_network_training.md) |
+| 3 | **LLM application engineering** | Prompting, structured outputs, tool use, RAG, context management | [LLM Fundamentals](../ai_genai/intro_llm_fundamentals.md), [RAG](../ai_genai/intro_rag.md), [Embeddings](../ai_genai/intro_embeddings.md) |
+| 4 | **Agents and orchestration** | Planning loops, tool schemas, multi-agent patterns, failure recovery, when *not* to use an agent | [Agentic AI](../ai_genai/intro_agentic_ai.md), [Multi-Agent Systems](../ai_genai/intro_multi_agent_systems.md), [MCP](../ai_genai/intro_mcp.md) |
+| 5 | **Evaluation** | Offline vs online metrics, LLM-as-judge, regression suites, hallucination detection | [Model Evaluation](../classical_ml/intro_model_evaluation.md), [LLM Evaluation](../mlops/intro_llm_evaluation.md), [Guardrails](../mlops/intro_evaluation_guardrails.md) |
+| 6 | **MLOps and production** | Deployment, drift, experiment tracking, CI/CD, rollback, monitoring | [MLOps](../mlops/README.md), [Model Monitoring](../mlops/intro_model_monitoring.md), [Model Serving](../mlops/intro_model_serving.md) |
+| 7 | **System design** | Latency, throughput, cost, caching, batching, failure modes, capacity | [System Design](../system_design/README.md), [Design Patterns](../system_design/ml_system_design_patterns.md), [Inference Optimization](../ai_genai/intro_llm_inference_optimization.md) |
+| 8 | **Responsible AI and security** | Prompt injection, tool permissions, PII handling, bias, governance | [LLM Security](../ai_genai/intro_llm_security.md), [Explainability](../mlops/intro_model_explainability.md) |
+
+---
+
+## Role-by-Role Focus Matrix
+
+Priority: **●●● critical** · **●● important** · **● useful**
+
+| Area | ML Engineer | AI / GenAI Engineer | Data Scientist | Data Engineer | MLOps / Platform |
+|---|---|---|---|---|---|
+| Classical ML | ●●● | ● | ●●● | ● | ●● |
+| Statistics / experiment design | ●● | ● | ●●● | ● | ● |
+| Deep learning | ●●● | ●● | ● | — | ● |
+| LLM app engineering | ●● | ●●● | ●● | ● | ●● |
+| RAG and embeddings | ●● | ●●● | ● | ●● | ●● |
+| Agents and tool use | ● | ●●● | ● | — | ●● |
+| Inference optimization | ●● | ●●● | — | — | ●●● |
+| Evaluation | ●●● | ●●● | ●●● | ● | ●●● |
+| MLOps / deployment | ●●● | ●● | ● | ●● | ●●● |
+| Data pipelines / modeling | ●● | ●● | ●● | ●●● | ●● |
+| System design | ●●● | ●●● | ● | ●●● | ●●● |
+| SQL | ●● | ● | ●●● | ●●● | ●● |
+| Python / coding round | ●●● | ●●● | ●● | ●●● | ●● |
+| Docker / K8s / IaC | ●● | ●● | — | ●● | ●●● |
+| Security and governance | ● | ●●● | ● | ●● | ●● |
+
+**How to read this**: your loop will test the ●●● rows properly and spot-check the ●● rows. Preparing the ● rows is what you do with leftover time, not first.
+
+---
+
+## The Typical Interview Loop
+
+| Stage | Format | What determines the outcome |
+|---|---|---|
+| **Recruiter screen** | 20–30 min | Can you describe your work in plain language? Level calibration. |
+| **Technical screen** | 45–60 min | Coding (Python/SQL) or an ML fundamentals rapid-fire round |
+| **Coding round** | 45–60 min | Data manipulation, occasionally [ML from scratch](../coding_challenges/ml_coding_challenges.md) |
+| **ML/AI depth round** | 60 min | Fundamentals with follow-ups going 3–4 layers deep |
+| **System design** | 60 min | An open-ended "design X" — the highest-variance round |
+| **Project deep-dive** | 45–60 min | Your own past work, interrogated in detail |
+| **Behavioral / hiring manager** | 45 min | Ownership, judgment, collaboration |
+
+Two rounds are under-prepared by almost everyone: the **project deep-dive** and **system design**. They are also the two with the widest score spread, which means they decide most loops. See [Behavioral and Project Deep-Dive](./behavioral-interview-guide.md) and the [System Design framework](../system_design/README.md).
+
+---
+
+## Study Plans by Time Available
+
+### 1 week — triage mode
+
+Assume you cannot learn anything new; you can only surface what you already know.
+
+| Day | Focus |
+|---|---|
+| 1 | [Model Evaluation](../classical_ml/intro_model_evaluation.md) + your target role's ●●● rows, skimmed for gaps |
+| 2 | Rehearse your [project deep-dive](./behavioral-interview-guide.md#the-project-deep-dive) out loud, twice. Look up your real numbers. |
+| 3 | [System design framework](../system_design/README.md) + one full case study end to end |
+| 4 | Coding: [Python](../coding_challenges/python_coding_challenges.md) or [SQL](../coding_challenges/sql_coding_challenges.md), whichever your loop tests |
+| 5 | Role-specific depth: [RAG](../ai_genai/intro_rag.md) + [Agents](../ai_genai/intro_agentic_ai.md), or [MLOps](../mlops/README.md) |
+| 6 | [2026 Additional Questions](./2026-additional-questions.md) — answer out loud, don't read |
+| 7 | [Behavioral stories](./behavioral-interview-guide.md), rest, logistics |
+
+### 1 month — the realistic plan
+
+| Week | Focus | Deliverable |
+|---|---|---|
+| 1 | Fundamentals: [classical ML](../classical_ml/README.md), [evaluation](../classical_ml/intro_model_evaluation.md), [ensembles](../classical_ml/intro_ensemble_methods.md), [statistics](../classical_ml/intro_statistics_probability.md) | Can explain bias/variance, leakage, and metric choice without notes |
+| 2 | Deep learning + LLM: [transformers](../deep_learning/intro_transformers.md), [training](../deep_learning/intro_neural_network_training.md), [LLM fundamentals](../ai_genai/intro_llm_fundamentals.md), [embeddings](../ai_genai/intro_embeddings.md), [RAG](../ai_genai/intro_rag.md) | A small working RAG app you can discuss |
+| 3 | Production: [MLOps](../mlops/README.md), [monitoring](../mlops/intro_model_monitoring.md), [serving](../mlops/intro_model_serving.md), [inference optimization](../ai_genai/intro_llm_inference_optimization.md), [Docker](../devops/intro_docker.md) | Your project, containerized and monitored |
+| 4 | Interview mechanics: [system design](../system_design/README.md) cases, [coding](../coding_challenges/README.md), [behavioral](./behavioral-interview-guide.md), mock loops | 3 rehearsed system designs, 8 STAR stories |
+
+### 3 months — build depth and a portfolio
+
+| Month | Focus |
+|---|---|
+| 1 | Fundamentals with implementation: work through [ML coding challenges](../coding_challenges/ml_coding_challenges.md), rebuild the classics from scratch, and read [classical ML](../classical_ml/README.md) + [deep learning](../deep_learning/README.md) properly |
+| 2 | Build one real project end to end — ingestion, model or LLM pipeline, evals, API, container, monitoring. See [Project Setup](../project_setup/README.md) and [Highlighted Projects](../README.md#highlighted-projects). This project becomes your deep-dive story. |
+| 3 | Interview preparation: [system design](../system_design/README.md) breadth, [2026 questions](./interview_questions_2026.md), weekly mock interviews, [behavioral](./behavioral-interview-guide.md) story bank |
+
+The three-month plan works because month 2 gives you something real to talk about. A candidate with one genuinely deep project outperforms one with five tutorials, every time.
+
+---
+
+## Depth Checklist
+
+Use this to find gaps. If you cannot answer a line in two minutes without notes, that's your next study session.
+
+**Fundamentals**
+- [ ] Explain bias/variance and name three ways to reduce each
+- [ ] Choose a metric for an imbalanced problem and defend it against accuracy and ROC-AUC
+- [ ] Detect and explain data leakage; name four ways it enters a pipeline
+- [ ] Explain why a random train/test split is wrong for temporal or grouped data
+- [ ] Compare bagging and boosting, including which base learner each needs and why
+
+**Deep learning**
+- [ ] Explain attention, including why scores are divided by `√d_k`
+- [ ] Diagnose a NaN loss, in order of likelihood
+- [ ] Explain why transformers use LayerNorm rather than BatchNorm
+- [ ] Explain what to do when a model doesn't fit in GPU memory, in escalating order
+
+**LLM and AI engineering**
+- [ ] Explain why RAG retrieval fails and how you'd tell retrieval from generation problems
+- [ ] Explain why LLM inference is memory-bandwidth-bound and what follows from it
+- [ ] Design an evaluation suite for a non-deterministic LLM feature
+- [ ] Explain prompt injection and how tool permissions bound the damage
+- [ ] Say when you would *not* use an agent
+
+**Production**
+- [ ] Describe how you'd detect that a deployed model has degraded
+- [ ] Explain training/serving skew and how a feature store prevents it
+- [ ] Describe a rollback plan for a model deploy
+- [ ] Estimate the cost per request of an LLM feature and name the three biggest levers
+
+**Communication**
+- [ ] Tell your best project story in 5 minutes, with real numbers
+- [ ] Tell a production failure story with root cause and systemic fix
+- [ ] Explain a model's performance to a non-technical stakeholder in their vocabulary
+
+---
+
+## The Week Before
+
+- **Re-read your own résumé and projects.** Interviewers ask about the line you wrote two years ago and forgot.
+- **Recover your numbers.** Dataset sizes, latency, cost, metric before/after. Approximate is fine; blank is not.
+- **Do one mock loop out loud**, ideally with another person. Reading is not rehearsal — the gap between knowing something and saying it fluently is larger than it feels.
+- **Prepare four questions per interviewer** and know who you're meeting.
+- **Stop learning new topics 48 hours out.** Consolidate what you have; new material at that point mostly adds noise.
+
+---
+
+## Related Topics
+
+- [2026 Additional Questions and Answers](./2026-additional-questions.md)
+- [2026 Common Interview Questions](./interview_questions_2026.md)
+- [Behavioral and Project Deep-Dive Guide](./behavioral-interview-guide.md)
+- [Study Pattern](./study-pattern.md)
+- [Resources and References](./resources-and-references.md)
+- [Repository Home](../README.md)

--- a/docs/behavioral-interview-guide.md
+++ b/docs/behavioral-interview-guide.md
@@ -1,0 +1,236 @@
+# Behavioral and Communication Rounds for ML/AI Roles
+
+Most candidates who fail an ML interview loop do not fail the technical rounds — they fail the behavioral round, the project deep-dive, or the "walk me through a past project" portion of a technical round. This guide covers the STAR structure, the ML-specific questions that actually get asked, how to present a project, and the failure modes that quietly sink otherwise strong candidates.
+
+---
+
+## Table of Contents
+1. [What These Rounds Actually Test](#what-these-rounds-actually-test)
+2. [The STAR Framework](#the-star-framework)
+3. [Building Your Story Bank](#building-your-story-bank)
+4. [The Project Deep-Dive](#the-project-deep-dive)
+5. [ML-Specific Behavioral Questions](#ml-specific-behavioral-questions)
+6. [Standard Behavioral Questions](#standard-behavioral-questions)
+7. [Handling Questions You Can't Answer](#handling-questions-you-cant-answer)
+8. [Questions to Ask Your Interviewer](#questions-to-ask-your-interviewer)
+9. [Level Expectations](#level-expectations)
+10. [Common Pitfalls](#common-pitfalls)
+11. [Related Topics](#related-topics)
+
+---
+
+## What These Rounds Actually Test
+
+Interviewers are checking four things, and every answer should feed at least one:
+
+| Signal | What they're looking for | How it shows up |
+|---|---|---|
+| **Ownership** | Did you drive an outcome, or narrate one? | "I" vs "we"; whether you know why decisions were made |
+| **Judgment** | Do you make good calls under ambiguity? | Tradeoffs you rejected and why |
+| **Impact** | Did the work matter to anyone outside your team? | Numbers tied to a business or user outcome |
+| **Collaboration** | Can you disagree, be wrong, and stay effective? | Conflict stories where you changed your mind |
+
+The thing that separates strong candidates is not better projects — it's **specificity**. "We improved the model" is worth nothing. "Recall at 90% precision went from 0.61 to 0.78, which cut manual review volume by about 4,000 cases a month" is worth the whole round.
+
+---
+
+## The STAR Framework
+
+| Element | Time | Content |
+|---|---|---|
+| **Situation** | ~15% | Context and constraints. Just enough to make the problem legible. |
+| **Task** | ~10% | What you specifically owned. |
+| **Action** | ~55% | What you did, what you considered, why you chose it. |
+| **Result** | ~20% | Quantified outcome, plus what you learned. |
+
+The most common failure is spending three minutes on Situation and thirty seconds on Action. Interviewers are evaluating your decisions, which live entirely in the Action section.
+
+### Weak vs strong, same story
+
+> **Weak**: "We had a churn model that wasn't working well, so I retrained it with better features and it improved a lot. The business was happy."
+
+> **Strong**: "Our churn model was flagging 12% of accounts monthly but the success team could only act on about 300, so precision at their working threshold mattered far more than AUC. *(Situation)* I owned the rebuild. *(Task)* I started by checking whether the offline metric matched their workflow — it didn't; we were reporting AUC 0.84 while precision at their operating point was 0.22. I reframed the metric as precision at the top 300 ranked accounts. Then I found the real problem in the features: `days_since_last_login` was computed at scoring time, not as-of the label date, so the model had partial label leakage. Fixing the as-of logic dropped offline AUC to 0.79 — which I had to explain carefully to my manager as an *improvement*. I added tenure and support-ticket-sentiment features, and used a gradient boosted model with the threshold set by the team's 300-case capacity. *(Action)* Precision in the top 300 went from 0.22 to 0.41, roughly doubling saved accounts per month at the same headcount. The bigger lesson was that the original model wasn't broken — the metric was wrong, and nobody had asked the success team how they actually worked. *(Result)*"
+
+The second version demonstrates metric selection, leakage detection, stakeholder communication, the courage to report a *worse* number, and business framing — five signals in ninety seconds.
+
+---
+
+## Building Your Story Bank
+
+Prepare **6–8 stories** covering the axes below. Most stories cover two or three axes, so you don't need one per row.
+
+| Axis | Prompt to prepare for |
+|---|---|
+| **Biggest technical impact** | "Tell me about your most impactful project" |
+| **Failure** | "Tell me about a model that failed in production" |
+| **Conflict / disagreement** | "Tell me about disagreeing with a senior colleague" |
+| **Ambiguity** | "Tell me about a project with unclear requirements" |
+| **Influence without authority** | "How did you get another team to change something?" |
+| **Tradeoff under pressure** | "Tell me about shipping something imperfect" |
+| **Learning something hard/fast** | "Tell me about picking up unfamiliar technology" |
+| **Mentoring / leadership** | "How have you grown someone on your team?" |
+
+For each story, write down: the **metric before and after**, the **specific decision you made**, the **alternative you rejected and why**, and **what you'd do differently**. That last one is where senior candidates separate themselves — a story with no retrospective reads as unexamined.
+
+**On honesty**: use real projects. Interviewers probe, and fabricated detail collapses under two follow-up questions. If your best story comes from a side project or coursework, say so plainly and focus on the decisions; a well-reasoned personal project beats a vaguely described production system.
+
+---
+
+## The Project Deep-Dive
+
+Many ML loops include a 45-minute round dedicated to one project. Expect it to go five layers deep. Prepare your strongest project to withstand that.
+
+**The structure that works** (roughly 5 minutes before questions start):
+
+1. **The problem in business terms** — who was hurting, and how much.
+2. **Why ML** — and what the non-ML baseline was. If you can't answer "why not a heuristic?", that's a red flag.
+3. **The data** — size, source, labels, and what was wrong with it.
+4. **Your approach** — model choice, and one meaningful alternative you rejected.
+5. **Evaluation** — offline metric, why that metric, and what the online result was.
+6. **Production** — how it was served, monitored, and what broke.
+7. **Impact and retrospective** — numbers, and the honest limitations.
+
+**Questions you will be asked, and should have ready:**
+
+- "Why that model and not something simpler?"
+- "What was your baseline, and how much did ML actually add over it?"
+- "How did you get labels? How noisy were they?"
+- "What would break if traffic increased 100x?"
+- "How did you know it was working in production?"
+- "What did you get wrong?"
+- "If you started over tomorrow, what would you change?"
+
+That last pair matters more than people expect. A candidate who says "nothing, it went well" sounds like they weren't paying attention. Have a real answer: an architectural choice you'd reverse, a metric you'd define differently, a monitoring gap you found the hard way.
+
+**Know your numbers.** Dataset size, class balance, latency, throughput, cost, and the before/after of your primary metric. Saying "I don't remember the exact figure, but it was roughly a 15-point recall improvement on about 2 million rows" is fine. Having no sense of scale at all is not.
+
+---
+
+## ML-Specific Behavioral Questions
+
+#### "Tell me about a model that failed in production."
+
+They want to see that you've operated a model, not just trained one. Strong answers name a *specific* failure mode — training/serving skew, feature drift, an upstream schema change, a delayed-label problem, a feedback loop where the model's own outputs poisoned its training data — and describe detection, mitigation, and the systemic fix.
+
+Structure: how you found out (ideally monitoring, not a customer complaint), what you did immediately (rollback, fallback to heuristic, kill switch), the root cause, and what you changed so that class of failure couldn't recur.
+
+> "Our recommendation CTR dropped 8% over two weeks with no deploy. Monitoring caught the prediction distribution shifting before anyone reported it. The cause was upstream: a data team changed a category taxonomy, and our one-hot encoder silently mapped the new values to the unknown bucket, so a third of items lost their category signal. Short-term I pinned the encoder and backfilled a mapping. Long-term I added schema validation on the feature pipeline with alerts on unknown-category rate, and set up a contract review with the upstream team. The real lesson was that we had model monitoring but no *input* monitoring."
+
+#### "How do you decide whether a problem needs ML at all?"
+
+Good answers start with the cost of being wrong and the availability of labels, and are visibly willing to say no. Rules to cite: if a handful of business rules get 90% of the value, ship the rules; if you can't define what a correct output looks like, you can't evaluate a model; if labels don't exist and can't be obtained, ML is a data-collection project first. ML earns its complexity when the pattern is genuinely hard to specify, the data exists, and the volume justifies the maintenance cost — because a deployed model is a permanent operational commitment, not a one-time build.
+
+#### "Tell me about a time you had to explain a model to a non-technical stakeholder."
+
+They're testing whether you can be trusted in front of a customer or an executive. The strongest answers translate the model into the listener's decisions: not "AUC is 0.87" but "out of every 100 accounts we flag, about 40 are real, and we catch roughly 3 of every 4 real cases — so at your review capacity, you'd catch this many more per month." Mentioning that you brought a *confusion matrix in their vocabulary* or a cost table rather than a metric name is a strong signal.
+
+#### "How do you handle a stakeholder who wants a model you don't think will work?"
+
+Don't say you refused; don't say you just built it. The good answer shows structured disagreement: understand the underlying goal (often the request is a solution, not a need), quantify the risk with a cheap experiment or a baseline, propose a smaller version that tests the premise, and commit to the decision once it's made. Show that you disagreed with evidence and a timeline, not with an opinion.
+
+#### "Walk me through how you'd prioritize between improving model accuracy and reducing latency."
+
+Answer from the business, not preference: what does each buy? Estimate the value of an accuracy point (revenue, cost avoided) and the value of latency reduction (conversion impact, cost per request, SLO compliance). Say explicitly that you'd measure rather than assume, and that in most systems there's a knee in the curve where one is cheap and the other is expensive. Mentioning that you'd check whether the accuracy gain even changes any *decision* — a better AUC that never crosses a threshold changes nothing — is a strong differentiator.
+
+#### "Tell me about a time you had to work with bad data."
+
+Every ML engineer has this story and it should be specific: label noise, missingness that wasn't random, duplicate records, timestamps in mixed timezones, a join that silently multiplied rows. What they want is the *diagnosis process* — how you noticed, how you quantified the damage, and whether you fixed the data or the model. Bonus signal for saying you pushed a fix upstream rather than patching it in your pipeline forever.
+
+#### "How do you keep up with the field?"
+
+A trap for over-answering. Naming a sustainable, specific habit beats listing twenty sources: one or two newsletters, papers you actually read with a purpose, reproducing something notable, and a filter — you don't chase every model release, you evaluate when something changes a decision you're facing. Concrete beats comprehensive.
+
+---
+
+## Standard Behavioral Questions
+
+| Question | What they're really asking | Trap to avoid |
+|---|---|---|
+| "Tell me about yourself" | Can you tell a coherent story about your trajectory? | Reciting your résumé chronologically |
+| "Why this company/role?" | Have you done any homework? | Generic praise applicable to any company |
+| "Tell me about a conflict" | Can you disagree without being difficult? | Making the other person the villain |
+| "Your biggest failure" | Do you have self-awareness? | A humblebrag ("I care too much") |
+| "Where do you see yourself in 5 years?" | Will you be satisfied here? | An answer that describes a different job |
+| "Why are you leaving?" | Are you running from something? | Criticizing your current employer |
+| "Tell me about a time you were wrong" | Can you update? | Being wrong about something trivial |
+
+**On conflict stories**: the winning shape is *disagree → present evidence → the other person's concern turns out to be partly right → converge on something better*. A conflict story where you were simply right and everyone eventually agreed reads as either fabricated or as a person who doesn't hear feedback.
+
+**On failure stories**: pick a real failure with real consequences, take clear ownership without excessive self-flagellation, and land on the systemic change you made. The story is not "I made a mistake"; it's "I made a mistake, and here's how I made that class of mistake less likely for everyone."
+
+---
+
+## Handling Questions You Can't Answer
+
+This happens in every loop, and how you handle it is itself a strong signal.
+
+**Do**: say clearly what you don't know, then reason from what you do. "I haven't deployed a model with that constraint, but I'd reason about it this way..." is a *good* answer — it demonstrates transparency and reasoning under uncertainty, which is most of the job.
+
+**Do**: ask a clarifying question if the question is genuinely ambiguous. That's not stalling; it's what a competent engineer does.
+
+**Don't**: bluff. Interviewers ask follow-ups, and a confident wrong answer is far more damaging than an honest gap, because it makes everything else you said less trustworthy.
+
+**Don't**: freeze silently. Think out loud — the interviewer is assessing your process, and silence gives them nothing to assess.
+
+If you realize mid-answer that you were wrong, say so and correct it. "Actually, I don't think that's right — the reason is..." is a *positive* signal in nearly every loop.
+
+---
+
+## Questions to Ask Your Interviewer
+
+Ask questions that only make sense if you've thought about doing the job. Good ones:
+
+- "What does the path from a model idea to production look like here — who's involved and how long does it typically take?"
+- "How do you decide what to work on? Where do model ideas come from?"
+- "What's your monitoring and rollback story when a model degrades?"
+- "What's the split between building new models and maintaining existing ones?"
+- "What's something the team tried recently that didn't work?"
+- "What would make someone unsuccessful in this role?"
+- "How do data scientists, ML engineers, and platform engineers divide responsibilities here?"
+
+Avoid anything answered by the careers page, and save compensation and logistics for the recruiter rather than the technical panel.
+
+The last two questions are quietly the most useful ones *for you*: they surface whether the team has a realistic view of itself, and whether the role is what the job description claims.
+
+---
+
+## Level Expectations
+
+The same story is graded differently by level. Calibrate what you emphasize.
+
+| Level | Scope of stories | Emphasis |
+|---|---|---|
+| **Junior** | A well-executed component or model, with guidance | Learning speed, fundamentals, asking for help appropriately |
+| **Mid** | Owning a model end to end, in production | Independent execution, debugging, shipping reliably |
+| **Senior** | Owning a system; influencing other teams' decisions | Tradeoffs, ambiguity, mentoring, saying no to the wrong project |
+| **Staff+** | Direction across multiple teams; multi-quarter bets | Problem *selection*, organizational impact, technical strategy |
+
+The most common mis-calibration: senior candidates telling mid-level stories. If you're interviewing at senior level and every story is "I built a model and it worked", you'll be graded down even when the work was genuinely hard. Lead with the decision you made under ambiguity, the disagreement you resolved, or the project you killed — not the implementation.
+
+---
+
+## Common Pitfalls
+
+| Pitfall | Why it hurts | Fix |
+|---|---|---|
+| "We" throughout the whole story | Interviewer can't tell what you did | "The team decided X; I owned Y and made the call on Z" |
+| No numbers anywhere | Impact is unverifiable and forgettable | Metric before, metric after, business unit |
+| Five minutes of Situation | The Action section is what's being graded | Two sentences of context, then jump to decisions |
+| Only success stories | Reads as inexperienced or dishonest | Prepare two real failures with real consequences |
+| Blaming others in a conflict story | Signals you'll be hard to work with | Show what you learned from their position |
+| Rehearsed, word-for-word delivery | Sounds inauthentic; breaks under follow-ups | Memorize the *beats*, not the sentences |
+| Bluffing on an unknown | Follow-ups expose it and cost you credibility | "I don't know, here's how I'd approach it" |
+| "Nothing, it went well" as a retrospective | Suggests you didn't reflect on the work | Have one genuine thing you'd change |
+| Not knowing your own project's numbers | Undermines everything else you claimed | Review scale, metrics, and cost before the loop |
+| No questions at the end | Reads as disinterest | Prepare four, ask two or three |
+
+---
+
+## Related Topics
+
+- [2026 Interview Roadmap](./2026-interview-roadmap.md)
+- [Study Pattern](./study-pattern.md)
+- [2026 Additional Questions](./2026-additional-questions.md)
+- [ML System Design Framework](../system_design/README.md)
+- [Model Monitoring](../mlops/intro_model_monitoring.md)
+- [Resources and References](./resources-and-references.md)

--- a/index.html
+++ b/index.html
@@ -886,22 +886,25 @@ const TRACKS = [
   {
     id: 'docs', phase: 'start', icon: '🗺️', color: '#38bdf8',
     title: 'Roadmap & Study Guides',
-    desc: '2026 interview focus areas, structured study patterns by role, and curated resources.',
+    desc: '2026 interview focus areas, role-by-role study plans, behavioral and project deep-dive prep, and curated resources.',
     files: [
       { label: '2026 Roadmap', path: 'docs/2026-interview-roadmap.md' },
       { label: '2026 Interview Questions', path: 'docs/interview_questions_2026.md' },
       { label: 'Additional Questions', path: 'docs/2026-additional-questions.md' },
       { label: 'Study Pattern', path: 'docs/study-pattern.md' },
+      { label: 'Behavioral & Project Deep-Dive', path: 'docs/behavioral-interview-guide.md' },
       { label: 'Resources & References', path: 'docs/resources-and-references.md' },
     ]
   },
   {
     id: 'classical_ml', phase: 'foundations', icon: '📊', color: '#34d399',
     title: 'Classical ML',
-    desc: 'Statistics, clustering, dimensionality reduction, feature engineering, recommender systems, and time series.',
+    desc: 'Statistics, evaluation metrics, ensembles and gradient boosting, clustering, dimensionality reduction, feature engineering, and time series.',
     files: [
       { label: 'Overview', path: 'classical_ml/README.md' },
       { label: 'Statistics & Probability', path: 'classical_ml/intro_statistics_probability.md' },
+      { label: 'Model Evaluation & Metrics', path: 'classical_ml/intro_model_evaluation.md' },
+      { label: 'Ensemble Methods & Boosting', path: 'classical_ml/intro_ensemble_methods.md' },
       { label: 'Clustering', path: 'classical_ml/intro_clustering.md' },
       { label: 'Dimensionality Reduction', path: 'classical_ml/intro_dimensionality_reduction.md' },
       { label: 'Feature Engineering', path: 'classical_ml/intro_feature_engineering.md' },
@@ -912,19 +915,20 @@ const TRACKS = [
   {
     id: 'deep_learning', phase: 'foundations', icon: '🧠', color: '#10b981',
     title: 'Deep Learning',
-    desc: 'Transformer architecture, attention, computer vision, fine-tuning, and modern neural network design.',
+    desc: 'Transformer architecture, attention, training dynamics and optimization, computer vision, and fine-tuning.',
     files: [
       { label: 'Overview', path: 'deep_learning/README.md' },
       { label: 'Applied Deep Learning', path: 'deep_learning/intro_applied_deep_learning.md' },
       { label: 'Transformers', path: 'deep_learning/intro_transformers.md' },
       { label: 'Computer Vision', path: 'deep_learning/intro_computer_vision.md' },
       { label: 'Fine-Tuning', path: 'deep_learning/intro_fine_tuning.md' },
+      { label: 'NN Training & Optimization', path: 'deep_learning/intro_neural_network_training.md' },
     ]
   },
   {
     id: 'ai_genai', phase: 'genai', icon: '🤖', color: '#8b5cf6',
     title: 'AI & GenAI',
-    desc: 'LLM fundamentals, prompting, RAG, vector DBs, LLMOps, agents, multi-agent systems, MCP, LangChain, and the Claude API.',
+    desc: 'LLM fundamentals, prompting, RAG, embeddings, vector DBs, inference optimization, LLMOps, agents, MCP, LangChain, and the Claude API.',
     files: [
       { label: 'Agentic AI Engineer Roadmap', path: 'ai_genai/intro_agentic_ai_engineering_roadmap.md' },
       { label: 'LLM Fundamentals', path: 'ai_genai/intro_llm_fundamentals.md' },
@@ -934,6 +938,8 @@ const TRACKS = [
       { label: 'RAG Engineering', path: 'ai_genai/intro_rag_engineering.md' },
       { label: 'Vector Databases', path: 'ai_genai/intro_vector_databases.md' },
       { label: 'Vector Databases (Advanced)', path: 'ai_genai/intro_vector_databases_advanced.md' },
+      { label: 'Embeddings', path: 'ai_genai/intro_embeddings.md' },
+      { label: 'LLM Inference Optimization', path: 'ai_genai/intro_llm_inference_optimization.md' },
       { label: 'LLMOps', path: 'ai_genai/intro_llmops.md' },
       { label: 'Agentic AI', path: 'ai_genai/intro_agentic_ai.md' },
       { label: 'Agent Tool Use', path: 'ai_genai/intro_agent_tool_use.md' },
@@ -1048,10 +1054,11 @@ const TRACKS = [
   {
     id: 'coding_challenges', phase: 'mastery', icon: '⌨️', color: '#f472b6',
     title: 'Coding Challenges',
-    desc: 'Python and SQL practice for coding rounds, data interviews, and algorithmic screening.',
+    desc: 'Python, SQL, and implement-from-scratch ML practice for coding rounds and data interviews.',
     files: [
       { label: 'Overview', path: 'coding_challenges/README.md' },
       { label: 'Python Coding Challenges', path: 'coding_challenges/python_coding_challenges.md' },
+      { label: 'ML Coding Challenges', path: 'coding_challenges/ml_coding_challenges.md' },
       { label: 'SQL Coding Challenges', path: 'coding_challenges/sql_coding_challenges.md' },
     ]
   },

--- a/mlops/intro_evaluation_guardrails.md
+++ b/mlops/intro_evaluation_guardrails.md
@@ -131,6 +131,70 @@ eval-pipeline/
 
 ---
 
+## Interview Q&A
+
+#### How do you evaluate a system whose outputs are non-deterministic and open-ended?
+
+Convert "is this good?" into checkable claims, in layers:
+- **Deterministic checks** first — schema validity, required fields present, citation spans exist, no PII in output, length bounds. These are cheap, exact, and catch most regressions.
+- **Reference-based metrics** where a correct answer exists — exact match, F1 over extracted fields, or retrieval recall.
+- **LLM-as-judge** for subjective dimensions (helpfulness, faithfulness, tone), validated against human labels on a sample before you trust it.
+- **Human review** on a rotating sample and on everything the judge scores near its threshold.
+
+Then fix a **regression suite**: a versioned set of cases with expected properties, run on every prompt, model, retrieval, or tool change. Non-determinism is handled by running each case several times and tracking the pass *rate*, not a single pass/fail.
+
+#### How do you validate an LLM judge?
+
+Treat it as a model you're deploying, because it is. Label a few hundred examples by hand, then measure the judge's agreement with those labels — Cohen's kappa or simple agreement rate, and crucially agreement on the *disagreement cases*, since a judge that only agrees on obvious examples is useless.
+
+Then test for the known biases: **position bias** (swap the order of two compared answers and check the verdict flips at chance rate, not systematically), **verbosity bias** (longer answers scoring higher regardless of quality), **self-preference** (a judge favoring outputs from its own model family), and score compression (everything lands at 4/5). Use a rubric with concrete criteria rather than "rate 1–10", and prefer pairwise comparison over absolute scoring — it's substantially more reliable.
+
+#### What guardrails would you put around a customer-facing LLM feature?
+
+Input side: prompt-injection detection, PII detection and redaction before the text reaches the model, length and rate limits, and topic classification to reject out-of-scope requests early.
+
+Output side: schema validation for structured responses, a safety/moderation classifier, PII scanning on the way out (models can echo back what was retrieved), citation verification for grounded answers, and a claim-checker for high-stakes domains.
+
+Around both: a kill switch to disable the feature without a deploy, a fallback response for when a guardrail trips, per-user rate and spend limits, and full request/response logging with retention that legal has agreed to.
+
+The framing that matters: guardrails are a **defense-in-depth system with a failure mode of its own**. Over-blocking is a real cost — measure the false-positive rate of your guardrails, not just their catch rate, or you'll ship a feature that refuses legitimate requests.
+
+#### How do you red-team an AI system before launch?
+
+Systematically, against a threat model rather than by improvising. Enumerate what an attacker wants — extract the system prompt, exfiltrate other users' data, make the model take an unauthorized action through a tool, produce harmful content, or run up cost. Then attack each: direct and indirect prompt injection (including content the system retrieves, which is the underrated vector), jailbreak patterns, role-play framing, encoding tricks, and multi-turn escalation where each message is individually benign.
+
+Record every successful attack as a permanent regression test. The measure of a red-team exercise is not how many issues it found but whether the same attack class fails on the next release — which only happens if the findings become tests.
+
+#### How do you detect hallucination in production, not just in evals?
+
+No single signal is sufficient, so combine cheap ones: **groundedness checking** (does each claim appear in the retrieved context — an NLI model or a judge call on a sample), **self-consistency** (sample the answer several times and flag high disagreement), **citation validation** (do the cited spans actually exist and support the claim), and **user signals** (thumbs-down, rephrasing, escalation to a human).
+
+For rate-limited cost, sample rather than checking everything: score 1–5% of traffic continuously and alert on the rate rather than individual cases. And monitor the abstention rate — a fall in "I don't know" responses often precedes a rise in confident fabrication.
+
+#### What do you do when evaluation results and user feedback disagree?
+
+Trust the users and fix the eval. The disagreement means the eval set doesn't represent real traffic — usually because it was written by the team rather than sampled from production, so it under-represents ambiguous, adversarial, or multi-turn cases.
+
+The fix is a feedback loop: sample real failures, label them, and add them to the eval set, so the suite converges on reality over time. Also check for the mundane explanations first — the eval runs a different prompt version, different retrieval settings, or a different model than production.
+
+---
+
+## Common Pitfalls
+
+| Pitfall | Why it hurts | Fix |
+|---|---|---|
+| Vibes-based evaluation | No way to detect regressions or compare versions | A versioned regression suite run on every change |
+| Trusting an LLM judge without validation | Position, verbosity, and self-preference biases go unmeasured | Validate against human labels; use pairwise comparison |
+| Eval set written by the team, not sampled from traffic | Misses ambiguous and adversarial real cases | Continuously add labeled production failures |
+| Single run per eval case | Non-determinism reads as a regression | Multiple runs; track pass rate |
+| Measuring guardrail catch rate only | Over-blocking silently destroys the user experience | Track false-positive rate as an equal metric |
+| Red-team findings not converted to tests | The same attack class returns next release | Every successful attack becomes a regression case |
+| Guardrails only on input | Models echo retrieved PII and unsupported claims outward | Symmetric input and output checks |
+| No kill switch | Disabling a broken feature requires a deploy | Runtime feature flag with a safe fallback response |
+| Evaluating end to end only | Cannot localize whether retrieval, prompt, or model regressed | Stage-level metrics alongside end-to-end |
+
+---
+
 ## Related Topics
 
 - [LLM Evaluation](./intro_llm_evaluation.md)

--- a/mlops/intro_llmops_mlops_engineering.md
+++ b/mlops/intro_llmops_mlops_engineering.md
@@ -124,6 +124,68 @@ ai-cicd/
 
 ---
 
+## Interview Q&A
+
+#### How does LLMOps differ from traditional MLOps?
+
+The pipeline shape is similar; the hard parts move. In MLOps the artifact is a trained model and the risks are drift, retraining, and reproducibility. In LLMOps the model is often someone else's and unchangeable, so the artifacts you version are **prompts, retrieval indexes, tool definitions, and model versions** — and the deployment risk is that a provider silently updates the model under you.
+
+Other genuine differences: outputs are non-deterministic, so testing is statistical rather than exact; evaluation has no ground-truth label for most requests; cost is per-request and unbounded rather than a fixed serving cost; and latency is dominated by generation length, which the model itself decides. Security also enters the runtime path — prompt injection is a live attack surface that has no MLOps analogue.
+
+What stays identical: you still need versioning, staged rollout, monitoring, rollback, and a regression suite. Candidates who claim LLMOps is entirely new usually haven't operated either.
+
+#### What do you version in an LLM application, and why does it matter?
+
+Everything that can change the output: the prompt template, the model ID *and* provider version, sampling parameters, the tool schemas, the retrieval index version and embedding model, the chunking configuration, and the eval suite version. Bundle them into one immutable release artifact rather than versioning each independently.
+
+The reason is debuggability. Without it, "quality dropped last Tuesday" is unanswerable — you cannot tell whether someone edited a prompt, the index was reindexed, or the provider shipped a new model snapshot. Pinning provider model *snapshots* rather than floating aliases is the specific practice that saves you here.
+
+#### How do you deploy a prompt change safely?
+
+Like a code change, because it is one. It goes through review, runs against the regression suite in CI, and ships behind a flag with a staged rollout — a small traffic percentage first, watching quality signals, error rate, latency, and cost before widening. Keep the previous version live for instant rollback.
+
+The additional LLM-specific step is a **shadow run**: send a sample of production traffic to the new prompt without serving its output, and compare against the current one offline. It catches regressions on real inputs that a curated eval set misses, at no user risk.
+
+#### What do you monitor for an LLM feature in production?
+
+Four layers:
+- **System**: latency (TTFT and total, at p50/p95/p99), error rate by type, timeout rate, provider availability.
+- **Cost**: tokens in and out per request, cost per request and per user, cache hit rate, and spend against budget with alerting *before* the limit.
+- **Quality**: sampled automated evals, user feedback signals, abstention rate, guardrail trip rate, schema validation failure rate, and for agents the tool error rate and step count distribution.
+- **Behavioral drift**: input distribution shift (are users asking different things?) and output length distribution, both of which move before quality metrics do.
+
+The cheapest high-value alert is on **schema validation failures** — it catches provider model changes, prompt regressions, and malformed tool calls in one signal.
+
+#### How do you trace a multi-step agent request for debugging?
+
+Structured tracing with a span per step, all correlated by one request ID: the initial prompt, each model call with its full input and output, each tool invocation with arguments and result, retrieval queries and returned document IDs, retries, and the final response. Record token counts and latency per span so you can attribute cost and time to a specific step.
+
+That's what LangSmith, Langfuse, and OpenTelemetry-based setups provide. The point is that agent failures are almost never in the last step — a bad answer usually traces back to a tool returning something unexpected five steps earlier, and without span-level traces you're guessing.
+
+#### How do you control LLM spend?
+
+Instrument before optimizing: cost per request broken down by feature, user, and route, so you know where the money goes. Then the levers in order of impact for most systems: prompt caching (input tokens usually dominate), trimming retrieved context, routing easy requests to a smaller model, semantic caching for repeated queries, capping `max_tokens`, and moving offline work to batch APIs.
+
+Add hard controls too: per-user and per-tenant rate and spend limits, a global budget circuit breaker, and alerting on cost-per-request anomalies. An agent stuck in a retry loop can burn a month's budget in an afternoon, so a step limit and a per-request cost ceiling are not optional.
+
+---
+
+## Common Pitfalls
+
+| Pitfall | Why it hurts | Fix |
+|---|---|---|
+| Prompts edited in production without review | No history, no rollback, no test coverage | Prompts in version control, reviewed and CI-tested |
+| Floating model aliases instead of pinned snapshots | The provider updates the model and quality shifts silently | Pin snapshot versions; upgrade deliberately with an eval run |
+| Versioning the prompt but not the index or embedding model | A reindex changes behavior with no trace | One immutable release artifact covering all components |
+| No per-request cost ceiling or step limit | A looping agent can burn the budget in hours | Hard caps plus a budget circuit breaker |
+| Logging only the final response | Agent failures originate several steps earlier | Span-level tracing with a shared request ID |
+| Monitoring latency only in aggregate | TTFT and total latency have different causes | Track TTFT and per-token latency separately at p95/p99 |
+| Shipping a prompt change to 100% of traffic | No safe way to observe a regression | Staged rollout behind a flag, with shadow comparison |
+| No alerting on schema validation failures | The earliest signal of model or prompt regression is missed | Alert on validation failure rate |
+| Treating evaluation as a launch gate only | Quality drifts as inputs and providers change | Continuous sampled evaluation in production |
+
+---
+
 ## Related Topics
 
 - [MLOps Overview](./README.md)

--- a/mlops/intro_mlflow.md
+++ b/mlops/intro_mlflow.md
@@ -585,9 +585,9 @@ The default MLflow server has no authentication. Anyone with network access can 
 
 ## Related Topics
 
-- [Intro to Kubeflow Pipelines](intro_kubeflow.md) — Orchestrating ML pipelines on Kubernetes
+- [Kubernetes](../devops/intro_kubernetes.md) — Orchestrating ML workloads and pipelines on Kubernetes
 - [Intro to Model Serving](intro_model_serving.md) — TF Serving, Triton, BentoML, and serving strategies
 - [Intro to Feature Stores](intro_feature_stores.md) — Feast, Tecton, and managing ML features
 - [Intro to Model Explainability](intro_model_explainability.md) — SHAP, LIME, and interpretability
 - [Intro to Data Quality](intro_data_quality.md) — Great Expectations, data contracts, and drift detection
-- [Intro to CI/CD for ML](intro_cicd_ml.md) — Automating ML pipelines with GitHub Actions and Jenkins
+- [GitHub Actions](../devops/intro_github_actions.md) — Automating ML pipelines and model CI/CD

--- a/mlops/intro_model_explainability.md
+++ b/mlops/intro_model_explainability.md
@@ -564,4 +564,4 @@ SHAP explains what the model learned, not what is correct. A model that perfectl
 - [Intro to Model Serving](intro_model_serving.md) — Deploying models and logging predictions for explanation storage
 - [Intro to Data Quality](intro_data_quality.md) — Data drift detection and validation
 - [Intro to Feature Stores](intro_feature_stores.md) — Managing features that feed into explainability analyses
-- [Fairness and Bias in ML](../ml_concepts/fairness_bias.md) — Algorithmic fairness metrics and mitigation strategies
+- [Model Evaluation and Metrics](../classical_ml/intro_model_evaluation.md) — Metric choice, calibration, and slicing metrics by segment to surface bias

--- a/system_design/intro_backend_ai_system_design.md
+++ b/system_design/intro_backend_ai_system_design.md
@@ -145,6 +145,78 @@ scalable-ai-api/
 
 ---
 
+## Interview Q&A
+
+#### Design an API that serves an LLM feature to 10,000 concurrent users. Where do you start?
+
+With numbers, before architecture. Ask for the request rate, the prompt and output token distributions, the latency SLO, and the cost budget — those four determine everything else. 10,000 concurrent users is not 10,000 requests per second; if each user sends a request every 30 seconds, that's ~330 RPS, which is a very different system.
+
+Then the shape: a stateless API layer behind a load balancer (so it scales horizontally and any instance can serve any request), an async request path since LLM calls take seconds and blocking a thread per request destroys throughput, a queue with backpressure so overload degrades rather than collapses, streaming responses to cut perceived latency, and a caching layer — exact-match first, then semantic caching if the traffic repeats.
+
+The parts that separate a strong answer: **admission control** (reject early with a clear error rather than queueing indefinitely), **per-user rate and spend limits**, **timeouts at every hop** with values that sum to less than the client's timeout, and an explicit **degradation path** — a smaller model or a cached response when the primary is saturated.
+
+#### Why is async I/O particularly important for AI backends?
+
+Because the service spends nearly all its wall-clock time waiting on a network call to a model, not computing. In a synchronous thread-per-request server, a 3-second LLM call occupies a thread for 3 seconds; a few hundred concurrent requests exhausts the pool and new requests queue behind idle threads.
+
+With async, one process handles thousands of in-flight requests because each awaits its I/O and yields. The practical caveats worth stating: any blocking call in an async handler (a synchronous DB driver, a CPU-heavy tokenization, `time.sleep`) stalls the whole event loop, so it must move to a thread or process pool. And async raises concurrency, not per-request speed — it doesn't make the model faster.
+
+#### How do you handle a request that takes 60 seconds?
+
+Don't hold an HTTP connection open for it. Switch to an asynchronous job pattern: accept the request, return `202` with a job ID immediately, process on a worker pool, and let the client poll a status endpoint or receive a webhook or SSE push on completion. Persist job state so a worker restart doesn't lose it, and make the work idempotent by job ID so retries are safe.
+
+If the output is incrementally useful — generated text usually is — streaming is the better answer: the connection stays open but the user sees progress within a second, which changes the experience entirely even though total time is unchanged.
+
+#### What caching layers would you use, and what are their risks?
+
+Four, from cheapest to riskiest:
+- **Exact-match response cache** keyed by a hash of the full request (prompt, model, parameters). Safe and effective for repeated identical requests.
+- **Prompt/prefix cache** at the model provider or inference server, which requires ordering the prompt with the stable prefix first — often the single largest cost reduction in a RAG or agent system.
+- **Retrieval cache** for embeddings and search results, keyed by content hash.
+- **Semantic cache**, returning a previous answer for a sufficiently similar query. Powerful and the most dangerous — a threshold set too loosely serves confidently wrong answers to subtly different questions.
+
+Every cache needs an invalidation story tied to the underlying data, a TTL, and per-user scoping when responses are personalized or permission-dependent. A cache that ignores the requesting user is a data-leak vector, not just a correctness bug.
+
+#### How do you make an AI backend fail gracefully?
+
+Assume the model call fails, is slow, or is rate-limited, because it will be. Layer the defenses: timeouts at every hop; retries with exponential backoff and **full jitter**; a **circuit breaker** so a failing dependency stops absorbing every request's full timeout; **bulkheads** so one slow provider doesn't exhaust the shared connection pool; a **fallback chain** to an alternate provider, a smaller model, or a cached or templated response; and **load shedding** that rejects low-priority traffic early to protect the SLO for the rest.
+
+The framing that lands: decide in advance what "degraded" looks like and make it a designed state, not an accident. A user-visible "we're operating in reduced mode" beats a timeout, and both beat a cascade.
+
+#### How would you design for cost as a first-class constraint?
+
+Instrument cost per request end to end, attributed by feature, route, and tenant — you cannot control what you don't measure, and LLM cost is unusual in that it varies per request rather than being a fixed serving cost.
+
+Then design the controls in: per-user and per-tenant rate limits and spend caps, a global budget circuit breaker, `max_tokens` bounds, a step limit on any agent loop, prompt ordering that maximizes cache hits, and routing that sends the easy majority of traffic to a small model. Push offline work to batch APIs.
+
+The architectural point: cost belongs in the same category as latency and availability — it needs SLOs, monitoring, and alerting, not a monthly invoice surprise.
+
+#### How do you handle multi-tenancy safely?
+
+Tenant identity must be established at the edge from an authenticated token and carried through every layer as an explicit parameter — never inferred from a request body field a client controls. Every data access filters on it, including vector search, where post-filtering can both return empty pages and leak the existence of documents.
+
+Beyond correctness: per-tenant rate limits and spend caps so one tenant cannot exhaust shared capacity (the noisy-neighbor problem), per-tenant cache namespacing, and separate storage for tenants under regulatory isolation requirements. For a security-sensitive design, separate indexes per tenant is the defensible choice over a shared index with a mandatory filter — one missed filter in one code path is a breach.
+
+---
+
+## Common Pitfalls
+
+| Pitfall | Why it hurts | Fix |
+|---|---|---|
+| Synchronous handlers around LLM calls | Thread pool exhausts at low concurrency | Async I/O; move blocking work to a thread pool |
+| A blocking call inside an async handler | Stalls the entire event loop | Audit for sync DB drivers, CPU work, `time.sleep` |
+| Holding HTTP connections for long generations | Proxy timeouts, wasted resources, poor UX | Stream, or return a job ID and poll/webhook |
+| No timeout on an upstream model call | One hung request occupies capacity indefinitely | Timeouts at every hop, summing under the client's |
+| Retries without jitter or a circuit breaker | Retry storms turn a partial outage into a full one | Exponential backoff with full jitter + circuit breaker |
+| Unbounded queues | Latency grows until everything times out | Bounded queues with admission control and load shedding |
+| Semantic cache threshold set loosely | Serves confidently wrong answers | Tune the threshold on real queries; scope per user; add TTL |
+| Cache not scoped by user or tenant | Personalized or permissioned data leaks across users | Include identity in the cache key |
+| Tenant ID taken from the request body | Trivially spoofable; cross-tenant access | Derive from the authenticated token at the edge |
+| Stateful API instances | Cannot scale horizontally or restart safely | Keep session state in Redis or a database |
+| Cost measured only on the monthly invoice | No way to attribute or control spend | Per-request cost telemetry with budgets and alerts |
+
+---
+
 ## Related Topics
 
 - [Backend System Design Interview Guide](./backend_system_design_interview_guide.md)


### PR DESCRIPTION
## What

Fills the largest remaining content gaps in the repository and brings the roadmap-template guides up to the structure `CONTRIBUTING.md` requires (Interview Q&A + Common Pitfalls).

### Seven new guides (~26,000 words)

| File | Covers |
|---|---|
| `classical_ml/intro_ensemble_methods.md` | Bagging vs boosting, Random Forest and tree decorrelation, gradient boosting from first principles, XGBoost/LightGBM/CatBoost comparison, stacking, tuning order, feature importance |
| `classical_ml/intro_model_evaluation.md` | Confusion matrix, ROC-AUC vs PR-AUC, threshold selection by expected cost, probability calibration, regression and ranking metrics, CV strategies, offline vs online metrics |
| `deep_learning/intro_neural_network_training.md` | Initialization, activations, optimizers and AdamW, LR schedules and warmup, normalization layers, regularization, batch size, mixed precision, and a training debugging playbook |
| `ai_genai/intro_embeddings.md` | Contrastive training, similarity metrics, model selection, chunking strategies, fine-tuning with hard negatives, quantization and Matryoshka dimensions, retrieval evaluation |
| `ai_genai/intro_llm_inference_optimization.md` | Prefill vs decode, KV cache sizing, continuous batching, FlashAttention vs PagedAttention, quantization, speculative decoding, serving frameworks, cost modeling |
| `coding_challenges/ml_coding_challenges.md` | 15 implement-from-scratch problems (linear/logistic regression, K-Means, KNN, tree splits, PCA, backprop, attention, RRF, chunking) with reference solutions and follow-up questions |
| `docs/behavioral-interview-guide.md` | STAR structure, story bank, the project deep-dive round, ML-specific behavioral questions, level expectations |

### Expanded content

- **`docs/2026-interview-roadmap.md`** grew from a 1 KB bullet list to a full roadmap: what changed for 2026, a role-by-role focus matrix (ML Engineer / AI Engineer / Data Scientist / Data Engineer / MLOps), the typical interview loop, study plans for 1 week / 1 month / 3 months, and a depth checklist.
- **Eight guides** that were missing the required sections now have **Interview Q&A** and **Common Pitfalls**: `rag_engineering`, `multimodal_ai`, `multi_model_orchestration`, `evaluation_guardrails`, `llmops_mlops_engineering`, `data_engineering_for_ai`, `backend_ai_system_design`, `applied_deep_learning`.

### Navigation and fixes

- All new files registered in the `index.html` track registry, with updated track descriptions.
- README quick navigation, repository structure, and the Classic ML / Deep Learning / AI-GenAI / Coding Challenges track lists updated.
- Fixed three pre-existing links pointing at files that do not exist: `intro_kubeflow.md`, `intro_cicd_ml.md`, and `ml_concepts/fairness_bias.md`.

## Why

The repository covered LLM and agent tooling well but had no standalone guide for ensembles or evaluation metrics — the two most-asked classical ML areas. It also had no behavioral or project-deep-dive material despite those rounds deciding most interview loops, and no implement-from-scratch coding practice. Separately, several guides added from a common template stopped short of the Interview Q&A and Common Pitfalls sections `CONTRIBUTING.md` lists as required.

## Verification

- All **619** relative links in the repository resolve (0 broken, down from 3).
- All **106** paths in the `index.html` registry point at existing files.
- All TOC anchors in the new guides match their headings.
- All **41** Python code blocks in the new guides parse under `ast.parse`.
- Extracted `index.html` scripts pass `node --check`.

## Preview

Start at [`docs/2026-interview-roadmap.md`](https://github.com/shafaypro/CrackingMachineLearningInterview/blob/claude/repo-exploration-content-jd3g58/docs/2026-interview-roadmap.md) — the role matrix and study plans link into everything else.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WAYFF5JQvb2dNufRk2rMcL

---
_Generated by [Claude Code](https://claude.ai/code/session_01WAYFF5JQvb2dNufRk2rMcL)_