### PR TITLE
Add sequence models, context engineering, CI/CD and take-home guides + track indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Please check out [CrackingMachineLearningInterview](https://shafaypro.github.io/
 * [2026 Additional Questions and Answers](./docs/2026-additional-questions.md)
 * [2026 Common Interview Questions (New)](./docs/interview_questions_2026.md)
 * [Behavioral & Project Deep-Dive Guide (New)](./docs/behavioral-interview-guide.md)
+* [ML Take-Home Projects & Case Studies (New)](./docs/take-home-projects.md)
 * [AI / GenAI Track](#ai--genai-track)
 * [Classic ML Track](#classic-ml-track)
 * [Deep Learning Track](#deep-learning-track)
@@ -62,6 +63,7 @@ Feel free to share the repository link in your blog, study notes, or interview p
 * [`docs/resources-and-references.md`](./docs/resources-and-references.md): books, references, and additional interview topics.
 * [`docs/study-pattern.md`](./docs/study-pattern.md): recommended preparation topics, difficulty levels, and study structure.
 * [`docs/behavioral-interview-guide.md`](./docs/behavioral-interview-guide.md): STAR stories, the project deep-dive round, ML-specific behavioral questions, and level expectations. **(New)**
+* [`docs/take-home-projects.md`](./docs/take-home-projects.md): what reviewers score, time budgeting, repository structure, and the follow-up presentation round. **(New)**
 * [`ai_genai/`](./ai_genai): GenAI and LLM engineering topics including n8n, CrewAI, LangGraph, LangSmith, multi-agent systems, and advanced RAG. **(Expanded)**
 * [`classical_ml/`](./classical_ml): classical ML algorithms — time series, clustering, dimensionality reduction, recommender systems, feature engineering.
 * [`mlops/`](./mlops): MLOps topics — MLflow, model serving, feature stores, explainability, data quality, LLM evaluation. **(Expanded)**
@@ -111,6 +113,7 @@ Core topics:
 * [LLM & Generative AI Fundamentals](./ai_genai/intro_llm_fundamentals.md) **(New)**
 * [RAG](./ai_genai/intro_rag.md)
 * [RAG Engineering](./ai_genai/intro_rag_engineering.md) **(New)**
+* [Context Engineering (budgets, ordering, caching, memory, compaction)](./ai_genai/intro_context_engineering.md) **(New)**
 * [Embeddings (models, chunking, fine-tuning, quantization)](./ai_genai/intro_embeddings.md) **(New)**
 * [Vector Databases](./ai_genai/intro_vector_databases.md)
 * [Vector Databases — Advanced (Pinecone, Weaviate, FAISS, pgvector, Hybrid Search, Reranking)](./ai_genai/intro_vector_databases_advanced.md) **(New)**
@@ -158,6 +161,7 @@ Use this track for ML engineer, deep learning engineer, and applied AI interview
 Core topics:
 * [Deep Learning Overview](./deep_learning/README.md)
 * [Applied Deep Learning Roadmap](./deep_learning/intro_applied_deep_learning.md) **(New)**
+* [Sequence Models (RNN, LSTM, GRU, Seq2Seq, Attention)](./deep_learning/intro_sequence_models.md) **(New)**
 * [Transformers](./deep_learning/intro_transformers.md)
 * [Neural Network Training (optimizers, normalization, regularization, debugging)](./deep_learning/intro_neural_network_training.md) **(New)**
 * [Computer Vision (CNNs, Detection, Segmentation, ViT)](./deep_learning/intro_computer_vision.md) **(New)**
@@ -192,6 +196,7 @@ Use this track for MLOps Engineer, Senior ML Engineer, and production ML system 
 
 Core topics:
 * [LLMOps / MLOps Engineering](./mlops/intro_llmops_mlops_engineering.md) **(New)**
+* [CI/CD for Machine Learning (registry, gates, canary, rollback)](./mlops/intro_cicd_for_ml.md) **(New)**
 * [MLflow](./mlops/intro_mlflow.md)
 * [Model Explainability (SHAP, LIME)](./mlops/intro_model_explainability.md)
 * [Feature Stores](./mlops/intro_feature_stores.md)

--- a/ai_genai/intro_context_engineering.md
+++ b/ai_genai/intro_context_engineering.md
@@ -1,0 +1,322 @@
+# Context Engineering
+
+Prompt engineering is about wording. **Context engineering is about what goes into the window at all** — which facts, in what order, at what cost, and what gets dropped when the conversation outgrows the budget. It is now the dominant design activity in LLM applications, because in a RAG or agent system the model is rarely the bottleneck; what you chose to show it is.
+
+---
+
+## Table of Contents
+1. [Prompt Engineering vs Context Engineering](#prompt-engineering-vs-context-engineering)
+2. [The Context Budget](#the-context-budget)
+3. [Context Ordering and the Lost-in-the-Middle Effect](#context-ordering-and-the-lost-in-the-middle-effect)
+4. [Prompt Caching and Prefix Stability](#prompt-caching-and-prefix-stability)
+5. [Conversation Memory](#conversation-memory)
+6. [Compaction Strategies](#compaction-strategies)
+7. [Context for Agents](#context-for-agents)
+8. [Context Rot and Failure Modes](#context-rot-and-failure-modes)
+9. [Measuring Context Quality](#measuring-context-quality)
+10. [Interview Q&A](#interview-qa)
+11. [Common Pitfalls](#common-pitfalls)
+12. [Related Topics](#related-topics)
+
+---
+
+## Prompt Engineering vs Context Engineering
+
+| | Prompt engineering | Context engineering |
+|---|---|---|
+| Unit of work | Wording of an instruction | Composition of the whole window |
+| Typical question | "How do I phrase this?" | "What does the model need to see, and what must I leave out?" |
+| Failure it fixes | Model misunderstands the task | Model lacks the fact, or drowns in irrelevant text |
+| Cost impact | Marginal | Dominant — input tokens are most of the bill |
+| Scales with | Task complexity | Corpus size, conversation length, tool count |
+
+The shift happened because context windows grew. When the window was 4k tokens, the constraint was obvious and everyone economized. At 200k+, it became possible to stuff everything in — and teams discovered that **more context often makes answers worse**, not just more expensive. Deciding what to exclude turned into the real skill.
+
+---
+
+## The Context Budget
+
+Treat the window as a budget with named line items, not as a bucket.
+
+```
+┌─────────────────────────────────────────────────────┐
+│ System prompt + tool definitions      stable, cached │
+│ Few-shot examples                     stable, cached │
+├─────────────────────────────────────────────────────┤
+│ Long-term memory / user profile       semi-stable    │
+│ Conversation history                  growing        │
+│ Retrieved documents                   per-request    │
+│ Current user message                  per-request    │
+├─────────────────────────────────────────────────────┤
+│ Reserved headroom for the response    never fill     │
+└─────────────────────────────────────────────────────┘
+```
+
+Two rules follow directly:
+
+1. **Never plan to fill the window.** Reserve room for the output plus a safety margin. A request that fits at turn 10 and overflows at turn 11 is a production incident, and truncation errors surface as user-visible failures.
+2. **Order by stability, not by importance.** Everything that rarely changes goes first so the cached prefix stays valid; volatile content goes last.
+
+```python
+def assemble_context(system, tools, examples, memory, history, docs, question, budget=100_000):
+    """Fill from a fixed skeleton, trimming the elastic sections to fit."""
+    fixed = count_tokens(system) + count_tokens(tools) + count_tokens(examples)
+    reserved_for_output = 4_000
+    elastic = budget - fixed - reserved_for_output - count_tokens(question)
+
+    # Priority order when space is tight: memory > recent history > documents
+    memory_part  = truncate(memory, min(count_tokens(memory), int(elastic * 0.15)))
+    docs_part    = truncate(docs,   int(elastic * 0.50))
+    history_part = truncate(history, elastic - count_tokens(memory_part) - count_tokens(docs_part))
+
+    return [system, tools, examples, memory_part, history_part, docs_part, question]
+```
+
+**Count tokens, never characters.** A 4-chars-per-token rule of thumb is fine for a rough estimate and wrong at the boundary — code, JSON, non-English text, and long identifiers tokenize far denser. Use the provider's tokenizer for any check that gates a request.
+
+---
+
+## Context Ordering and the Lost-in-the-Middle Effect
+
+Models attend unevenly across a long context. Accuracy on retrieving a fact is highest when it sits near the **beginning or end** of the window and measurably lower in the middle — the "lost in the middle" finding. It has been reproduced across model families, and it holds even for models advertising very long windows.
+
+Practical consequences:
+
+- **Put the most relevant retrieved chunk last**, immediately before the question. Rerankers output a relevance order; placing rank 1 nearest the query beats placing it first in a long list.
+- **Repeat the instruction at the end** for very long contexts. A task instruction given 80k tokens earlier competes with everything since.
+- **Fewer, better chunks beat more chunks.** Passing 20 documents when 4 suffice both costs more and dilutes attention across irrelevant text.
+- **Structure the context.** Delimiters, headers, and per-source labels help the model locate what it needs and make citation possible.
+
+```python
+# Reranked descending by relevance — reverse so the strongest sits closest to the question
+context = "\n\n".join(
+    f"<document id=\"{d.id}\" source=\"{d.source}\" date=\"{d.date}\">\n{d.text}\n</document>"
+    for d in reversed(reranked[:4])
+)
+prompt = f"{context}\n\nAnswer using only the documents above, citing document ids.\n\nQuestion: {question}"
+```
+
+---
+
+## Prompt Caching and Prefix Stability
+
+Providers cache a request's prefix and charge a fraction of the normal input price for the cached portion; self-hosted servers skip the prefill compute entirely. The cache matches on an **exact prefix**, so a single changed byte early in the prompt invalidates everything after it.
+
+This makes prompt *ordering* an economic decision:
+
+| Layout | Cache behavior |
+|---|---|
+| `system → tools → examples → history → docs → question` | Prefix stable across turns; large cache hit |
+| `timestamp → system → docs → question` | A leading timestamp busts the cache on **every** request |
+| `user profile → system → ...` | Cache is per-user at best; no sharing across users |
+
+Concrete anti-patterns that silently destroy cache hit rate: injecting the current time or a request ID at the top; putting the user's name or tenant into the system prompt when it could go later; reordering tool definitions non-deterministically (a `set` or dict iteration that isn't stable); and re-summarizing conversation history every turn, which rewrites the middle of the prefix.
+
+For agents this matters enormously: an agent loop re-sends the whole conversation on each step, so a stable prefix can cut cost by an order of magnitude over a long run.
+
+---
+
+## Conversation Memory
+
+| Strategy | Mechanism | Best for | Weakness |
+|---|---|---|---|
+| **Full history** | Send everything | Short sessions | Grows without bound |
+| **Sliding window** | Keep last N turns | Chat with local context | Silently forgets early commitments |
+| **Summary buffer** | Summarize old turns, keep recent verbatim | Long conversations | Summarization loses detail and costs a call |
+| **Retrieval over history** | Embed turns, retrieve relevant ones | Very long or resumed sessions | Needs an index; can miss context |
+| **Structured memory** | Extract facts to a store (key-value or graph) | Assistants with persistent users | Extraction errors persist and compound |
+
+The strategy that works in practice is layered rather than singular: keep a small structured profile of durable facts, keep the last few turns verbatim, and summarize or retrieve the rest.
+
+```python
+class LayeredMemory:
+    """Durable facts + verbatim recent turns + summarized older turns."""
+
+    def __init__(self, keep_recent=6, summarize_after=20):
+        self.facts = {}            # durable, extracted: {"timezone": "CET", "role": "MLE"}
+        self.turns = []            # verbatim
+        self.summary = ""          # compacted older history
+        self.keep_recent = keep_recent
+        self.summarize_after = summarize_after
+
+    def add(self, role, content):
+        self.turns.append({"role": role, "content": content})
+        if len(self.turns) > self.summarize_after:
+            older, self.turns = self.turns[:-self.keep_recent], self.turns[-self.keep_recent:]
+            # Summarize into the EXISTING summary so it stays append-only and cache-friendly
+            self.summary = summarize(self.summary, older)
+
+    def render(self):
+        parts = []
+        if self.facts:
+            parts.append("Known facts:\n" + "\n".join(f"- {k}: {v}" for k, v in self.facts.items()))
+        if self.summary:
+            parts.append(f"Earlier conversation summary:\n{self.summary}")
+        return parts + self.turns
+```
+
+**What must survive compaction**: decisions and commitments made, constraints the user stated, corrections the user issued (an assistant that re-makes a corrected mistake destroys trust faster than any other failure), identifiers and names, and open questions. What can be dropped: pleasantries, superseded intermediate reasoning, and tool output already reflected in a conclusion.
+
+---
+
+## Compaction Strategies
+
+When a conversation approaches the budget, something must go. Options, roughly in order of fidelity:
+
+1. **Drop tool call bodies, keep conclusions.** Tool outputs are usually the largest and most disposable content — a 3,000-token API response reduces to "the query returned 14 rows; the top account is X."
+2. **Summarize the oldest span** into the existing summary, leaving recent turns verbatim.
+3. **Deduplicate.** Retrieved documents repeat across turns in RAG chats; keep one copy.
+4. **Externalize.** Write long artifacts to a file or store and keep a reference the model can re-read on demand, rather than carrying them inline.
+5. **Hard-truncate the middle**, keeping the head (system, task) and tail (recent turns). Crude but predictable, and better than an overflow error.
+
+Compaction should be **idempotent and append-only** where possible. Re-summarizing the whole history each turn produces a different prefix every time, which both busts the cache and lets facts drift as summaries of summaries degrade.
+
+---
+
+## Context for Agents
+
+Agent loops re-send accumulated context at every step, so context growth is the main driver of both cost and failure over a long run.
+
+- **Tool definitions are permanent context.** Twenty tools with verbose schemas can consume several thousand tokens on every single step. Trim descriptions, and load tools by task phase rather than exposing all of them always.
+- **Tool results are the fastest-growing segment.** Truncate large outputs at the boundary, with an explicit marker, and give the agent a way to request more.
+- **Subagents isolate context.** Delegating a research subtask to a subagent that returns only its conclusion keeps the parent's window clean — this is the main practical argument for multi-agent designs, more than any notion of specialization.
+- **Externalize state.** A scratchpad file or task list the agent reads and writes beats carrying all intermediate reasoning inline.
+
+```python
+MAX_TOOL_RESULT_TOKENS = 2_000
+
+def add_tool_result(messages, tool_name, result):
+    text = str(result)
+    if count_tokens(text) > MAX_TOOL_RESULT_TOKENS:
+        text = (truncate(text, MAX_TOOL_RESULT_TOKENS)
+                + f"\n\n[truncated — {count_tokens(str(result))} tokens total. "
+                  f"Call {tool_name} with a narrower filter for specifics.]")
+    messages.append({"role": "tool", "name": tool_name, "content": text})
+```
+
+---
+
+## Context Rot and Failure Modes
+
+| Failure | What it looks like | Cause | Fix |
+|---|---|---|---|
+| **Distraction** | Answer drifts to an irrelevant retrieved document | Too many low-relevance chunks | Rerank; pass fewer |
+| **Lost in the middle** | A fact that *is* in context is ignored | Poor position | Put key content at the end |
+| **Context poisoning** | A hallucination early on is treated as fact later | Model's own error persists in history | Validate before appending; drop bad turns |
+| **Instruction dilution** | Model stops following the format after many turns | Instruction is far away and outnumbered | Restate constraints near the end |
+| **Stale context** | Answers from an outdated retrieved doc | No recency signal | Timestamp metadata; prefer recent sources |
+| **Conflicting sources** | Confidently picks one of two contradictory docs | No precedence rule | Rank by authority and recency; ask the model to flag conflicts |
+| **Silent truncation** | Answer omits something that was "in" the prompt | Middle-out truncation by the client or provider | Count tokens yourself; fail loudly |
+
+**Context poisoning** deserves emphasis because it is specific to multi-turn systems and easy to miss: once a model states something false and that turn stays in history, the falsehood is now "established context" the model will defend and build on. Validating tool results and model claims *before* they enter durable history is far cheaper than detecting the downstream damage.
+
+---
+
+## Measuring Context Quality
+
+Do not evaluate the prompt; evaluate what the context enables.
+
+| Metric | Question it answers |
+|---|---|
+| **Retrieval recall@k** | Is the needed fact even in the window? |
+| **Context precision** | What fraction of included tokens are relevant? |
+| **Faithfulness / groundedness** | Are claims supported by what was provided? |
+| **Citation accuracy** | Do cited spans exist and support the claim? |
+| **Cache hit rate** | Is the prefix actually stable? |
+| **Tokens per resolved request** | The real cost metric |
+| **Truncation rate** | How often is content silently dropped? |
+
+The highest-signal diagnostic is a **needle test on your own corpus**: place a known fact at varying depths in a realistic context and measure retrieval accuracy by position. Published long-context benchmarks use synthetic haystacks and consistently overstate performance relative to real, semantically dense documents.
+
+The ablation worth running before shipping: hold the question set fixed and vary only the number of retrieved chunks (2, 4, 8, 16). Accuracy usually peaks well before the maximum, and the peak is your `top_k`.
+
+---
+
+## Interview Q&A
+
+#### What is context engineering and how does it differ from prompt engineering?
+
+Prompt engineering optimizes the *wording* of instructions — phrasing, examples, output format. Context engineering optimizes *what information enters the window at all*: which documents, how much history, in what order, within what token and cost budget, and what gets evicted when it overflows.
+
+The distinction became important once windows got large enough that "include everything" was possible. It turns out that including everything degrades quality — irrelevant context distracts the model, and content in the middle of a long window is attended to less reliably. So the job shifted from writing better instructions to curating a smaller, better-ordered context. In a RAG or agent system it is also where nearly all the cost lives, since input tokens dominate.
+
+#### The context window is 200k tokens. Should you just put everything in?
+
+No, for three separate reasons.
+
+**Quality**: accuracy degrades with irrelevant content. The lost-in-the-middle effect means a fact buried at 50% depth is retrieved less reliably than one at the edges, and distraction from low-relevance chunks measurably worsens answers.
+
+**Cost**: input tokens dominate a RAG bill. Sending 100k tokens to answer a question that needed 3k is a ~30x cost multiplier on every request, and it recurs on every agent step.
+
+**Latency**: prefill is compute-bound and scales with prompt length, so a huge prompt directly inflates time-to-first-token.
+
+The right approach is retrieve broadly, rerank, and pass the smallest context that reliably contains the answer — usually far fewer chunks than people expect, and worth determining empirically with a `top_k` ablation.
+
+#### How does prompt caching change how you structure a prompt?
+
+The cache keys on an exact prefix, so anything that varies must go **after** everything that doesn't. The layout becomes: system prompt, tool definitions, few-shot examples, then long-term memory, then conversation history, then retrieved documents, then the user's question.
+
+The consequences are concrete. A timestamp or request ID at the top of the system prompt invalidates the cache on every request — one of the most expensive one-line bugs in LLM applications. Non-deterministic tool ordering (iterating a set) does the same. Re-summarizing the whole history each turn rewrites the middle of the prefix and destroys the hit rate.
+
+Done right, cached input is typically around 10% of normal price, and for an agent loop that re-sends context every step it is often the single largest cost reduction available.
+
+#### What is the lost-in-the-middle effect and how do you design around it?
+
+Models retrieve facts from the start and end of a long context substantially more reliably than from the middle — a U-shaped accuracy curve by position, reproduced across model families and present even in long-context models.
+
+Design responses: put the highest-relevance retrieved chunk immediately before the question rather than first in the list; restate critical instructions at the end of a long context; reduce the number of chunks so there is less middle to get lost in; and add structural markers so content is locatable rather than uniform prose. Then verify on your own data with a needle test at varying depths, because synthetic benchmarks overstate real performance on semantically dense documents.
+
+#### How would you manage memory for an assistant used daily over months?
+
+Layered, because no single strategy covers it. A **structured profile** for durable facts — preferences, constraints, role, timezone — extracted deliberately and stored outside the conversation. **Recent turns verbatim**, since immediate context needs full fidelity. **A rolling summary** of older turns, updated append-only so the prefix stays cache-stable. **Retrieval over an archive** of past sessions for anything older, so a question about a conversation from March pulls in just that.
+
+The critical design detail is what survives compaction: decisions, commitments, stated constraints, and especially **user corrections**. An assistant that repeats a mistake the user already corrected loses trust faster than one that simply forgets. I'd also make memory writes auditable and user-editable, because extraction errors otherwise persist indefinitely and compound.
+
+#### What is context poisoning?
+
+When a model states something false and that turn remains in the conversation history, the falsehood becomes established context. On subsequent turns the model treats its own prior claim as a given, builds on it, and will often defend it against correction — a single hallucination compounds across a long session. The same happens with an erroneous tool result that is never validated.
+
+Mitigations are all about the write path: validate tool outputs before appending them, check claims against retrieved sources before they enter durable history, allow removing or correcting a poisoned turn rather than only appending, and keep durable memory extraction separate from raw conversation so a bad turn does not become a permanent "fact."
+
+#### An agent's cost grows superlinearly over a long run. Why, and what do you do?
+
+Because each step re-sends the entire accumulated context. If the conversation grows by roughly a constant amount per step, total tokens across `N` steps grow as `O(N²)`. Tool results are usually the fastest-growing segment, and verbose tool schemas are re-sent every single step.
+
+Fixes, in order of impact: **prompt caching** with a strictly stable prefix, so re-sent context costs a fraction; **truncate tool results** at a boundary with a marker and a way to request more; **compact** older steps into a summary once past a threshold; **externalize** long artifacts to files the agent reads on demand; **delegate to subagents** that return only conclusions, keeping the parent window small; and **trim tool definitions** or load them by phase. Plus a hard step limit and a per-request cost ceiling, because an agent stuck in a loop is the failure mode that produces the surprising invoice.
+
+#### How do you decide how many retrieved chunks to include?
+
+Empirically, with an ablation. Fix a labeled question set, vary only `top_k` (2, 4, 8, 16, 32), and measure end-to-end answer accuracy along with cost and latency. Accuracy almost always peaks at a modest value and then declines as irrelevant context dilutes attention — the peak is the answer, and it is usually lower than intuition suggests.
+
+Two refinements matter. Retrieve broadly (say 30) and **rerank** down to the final few, so the candidate set is wide but the context is tight. And measure retrieval recall separately: if recall@30 is poor, no amount of `top_k` tuning helps, and the problem is chunking or the embedding model rather than context assembly.
+
+---
+
+## Common Pitfalls
+
+| Pitfall | Why it hurts | Fix |
+|---|---|---|
+| Timestamp or request ID at the top of the prompt | Busts the prefix cache on every request | Move all volatile content to the end |
+| Filling the window to its limit | Overflow at turn N+1 becomes a user-visible failure | Reserve explicit output headroom |
+| Estimating tokens from character count | Code, JSON, and non-English tokenize far denser | Use the provider's tokenizer for any gating check |
+| Passing every retrieved chunk "just in case" | Higher cost *and* measurably worse answers | Rerank; ablate `top_k`; pass fewer |
+| Highest-relevance chunk placed first | Lands in the weakly-attended middle of a long list | Put it last, adjacent to the question |
+| Re-summarizing the entire history each turn | Rewrites the prefix, destroys caching, drifts facts | Append-only summary of the oldest span |
+| Appending unvalidated tool output to history | Errors become established context and compound | Validate before it enters durable history |
+| Non-deterministic tool definition order | Silent cache misses | Sort tool definitions deterministically |
+| Dropping user corrections during compaction | Assistant repeats a corrected mistake | Pin corrections and commitments as durable facts |
+| Trusting published long-context benchmarks | Synthetic haystacks overstate real performance | Needle test on your own corpus at varying depths |
+
+---
+
+## Related Topics
+
+- [Prompt Engineering](./intro_prompt_engineering.md)
+- [Intro to RAG](./intro_rag.md)
+- [RAG Engineering](./intro_rag_engineering.md)
+- [Embeddings](./intro_embeddings.md)
+- [Agentic AI](./intro_agentic_ai.md)
+- [Multi-Agent Systems](./intro_multi_agent_systems.md)
+- [LLM Inference Optimization](./intro_llm_inference_optimization.md)
+- [LLM Fundamentals](./intro_llm_fundamentals.md)
+- [LLM Evaluation](../mlops/intro_llm_evaluation.md)

--- a/classical_ml/README.md
+++ b/classical_ml/README.md
@@ -584,6 +584,21 @@ See [Statistics & Probability Guide](./intro_statistics_probability.md) for deta
 
 ---
 
+## Guides in This Track
+
+Every guide in `classical_ml/`. Start with the overview above, then work through these.
+
+- [Clustering Algorithms](./intro_clustering.md)
+- [Dimensionality Reduction (Deep Dive)](./intro_dimensionality_reduction.md)
+- [Ensemble Methods and Gradient Boosting](./intro_ensemble_methods.md)
+- [Feature Engineering & Selection](./intro_feature_engineering.md)
+- [Model Evaluation and Metrics](./intro_model_evaluation.md)
+- [Recommender Systems](./intro_recommender_systems.md)
+- [Statistics & Probability for ML Interviews](./intro_statistics_probability.md)
+- [Time Series Analysis & Forecasting](./intro_time_series.md)
+
+---
+
 ## References
 
 - [Scikit-learn Documentation](https://scikit-learn.org/stable/)

--- a/coding_challenges/README.md
+++ b/coding_challenges/README.md
@@ -133,3 +133,13 @@ You are in good shape if you can do the following without much hesitation:
 - reason about time-bucketed analytics queries
 
 If not, start with the two practice guides in this track and follow the linked concept guides.
+
+---
+
+## Guides in This Track
+
+Every guide in `coding_challenges/`. Start with the overview above, then work through these.
+
+- [ML Coding Challenges — Implement From Scratch](./ml_coding_challenges.md)
+- [Python Coding Challenges for Interviews](./python_coding_challenges.md)
+- [SQL Coding Challenges for Interviews](./sql_coding_challenges.md)

--- a/deep_learning/README.md
+++ b/deep_learning/README.md
@@ -550,6 +550,19 @@ Gradient accumulation delays optimizer updates for multiple forward/backward pas
 
 ---
 
+## Guides in This Track
+
+Every guide in `deep_learning/`. Start with the overview above, then work through these.
+
+- [Applied Deep Learning Roadmap](./intro_applied_deep_learning.md)
+- [Computer Vision for ML Interviews](./intro_computer_vision.md)
+- [Fine-Tuning Large Language Models: LoRA, QLoRA & PEFT](./intro_fine_tuning.md)
+- [Neural Network Training: Optimization and Regularization](./intro_neural_network_training.md)
+- [Sequence Models: RNNs, LSTMs, GRUs, and Seq2Seq](./intro_sequence_models.md)
+- [Transformers Deep Dive](./intro_transformers.md)
+
+---
+
 ## References
 
 - [Deep Learning — Ian Goodfellow, Yoshua Bengio, Aaron Courville (free online)](https://www.deeplearningbook.org/)

--- a/deep_learning/intro_sequence_models.md
+++ b/deep_learning/intro_sequence_models.md
@@ -1,0 +1,340 @@
+# Sequence Models: RNNs, LSTMs, GRUs, and Seq2Seq
+
+Transformers replaced recurrent networks for most language tasks, but sequence models remain standard interview material — they are where the vanishing-gradient problem becomes concrete, where the attention mechanism was invented to fix a real bottleneck, and where the "why transformers won" story actually starts. They are also still the right tool for streaming, low-latency, and small-data sequence problems.
+
+---
+
+## Table of Contents
+1. [Why Sequences Need Different Architectures](#why-sequences-need-different-architectures)
+2. [The Vanilla RNN](#the-vanilla-rnn)
+3. [Vanishing and Exploding Gradients](#vanishing-and-exploding-gradients)
+4. [LSTM](#lstm)
+5. [GRU](#gru)
+6. [Bidirectional and Stacked RNNs](#bidirectional-and-stacked-rnns)
+7. [Seq2Seq and the Bottleneck](#seq2seq-and-the-bottleneck)
+8. [Attention: The Fix That Became the Architecture](#attention-the-fix-that-became-the-architecture)
+9. [RNNs vs Transformers in Practice](#rnns-vs-transformers-in-practice)
+10. [Practical Training Notes](#practical-training-notes)
+11. [Interview Q&A](#interview-qa)
+12. [Common Pitfalls](#common-pitfalls)
+13. [Related Topics](#related-topics)
+
+---
+
+## Why Sequences Need Different Architectures
+
+A feed-forward network on sequence data has three problems: it needs a fixed input size, it has no notion of order, and it learns a separate weight for every position, so a pattern learned at position 3 does not transfer to position 40.
+
+Recurrent networks solve all three with **weight sharing across time**. One set of parameters is applied at every step, carrying a hidden state forward:
+
+```
+h_t = f(h_{t-1}, x_t)
+```
+
+This is the sequence analogue of what convolution does for images: the same feature detector applies everywhere, so the parameter count is independent of sequence length and patterns generalize across positions.
+
+---
+
+## The Vanilla RNN
+
+```
+h_t = tanh(W_hh · h_{t-1} + W_xh · x_t + b_h)
+y_t = W_hy · h_t + b_y
+```
+
+```python
+import torch
+import torch.nn as nn
+
+class VanillaRNNCell(nn.Module):
+    """One recurrent step, written out — this is the whiteboard version."""
+
+    def __init__(self, input_size, hidden_size):
+        super().__init__()
+        self.W_xh = nn.Linear(input_size, hidden_size, bias=False)
+        self.W_hh = nn.Linear(hidden_size, hidden_size, bias=True)
+
+    def forward(self, x_t, h_prev):
+        # x_t: (batch, input_size)   h_prev: (batch, hidden_size)
+        return torch.tanh(self.W_xh(x_t) + self.W_hh(h_prev))
+
+
+# Unrolling over a sequence
+def run_sequence(cell, xs, hidden_size):
+    # xs: (batch, seq_len, input_size)
+    batch = xs.size(0)
+    h = torch.zeros(batch, hidden_size, device=xs.device)
+    outputs = []
+    for t in range(xs.size(1)):
+        h = cell(xs[:, t, :], h)      # same weights reused at every step
+        outputs.append(h)
+    return torch.stack(outputs, dim=1), h   # (batch, seq_len, hidden), (batch, hidden)
+```
+
+**Backpropagation Through Time (BPTT)** is ordinary backprop on this unrolled graph. Its cost is what motivates everything that follows: the gradient at step 1 must pass through `T` multiplications by `W_hh`.
+
+**Truncated BPTT** caps that by backpropagating only `k` steps (commonly 32–256) instead of the full sequence. It bounds memory and compute at the price of never learning dependencies longer than `k`.
+
+---
+
+## Vanishing and Exploding Gradients
+
+Differentiating the loss at step `T` with respect to `h_1` produces a product of Jacobians:
+
+```
+∂h_T/∂h_1 = Π_{t=2..T} W_hh^T · diag(tanh'(z_t))
+```
+
+Two things go wrong, both exponential in sequence length:
+
+| Failure | Condition | Symptom | Fix |
+|---|---|---|---|
+| **Vanishing** | Largest singular value of `W_hh` < 1, or `tanh'` saturated | Early steps get no gradient; model learns only recent context | Gated units (LSTM/GRU), orthogonal init, skip connections |
+| **Exploding** | Largest singular value > 1 | Loss spikes to NaN; weights blow up | **Gradient clipping**, lower LR |
+
+Note `tanh'(z) = 1 - tanh²(z) ≤ 1`, and it approaches 0 as the unit saturates — so the activation derivative alone shrinks the signal at every step. This is why vanishing is the *typical* case and exploding is the dramatic one.
+
+Exploding gradients are easy to fix — clip the global norm and move on:
+
+```python
+torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+```
+
+Vanishing gradients are not fixable by clipping; they need an architectural change. That change is gating.
+
+---
+
+## LSTM
+
+The LSTM adds a **cell state** `C_t` that flows through time with only elementwise operations — no repeated matrix multiplication. Gates decide what to erase, what to write, and what to expose.
+
+```
+f_t = σ(W_f · [h_{t-1}, x_t] + b_f)        forget gate  — what to keep from C_{t-1}
+i_t = σ(W_i · [h_{t-1}, x_t] + b_i)        input gate   — how much new info to write
+C̃_t = tanh(W_C · [h_{t-1}, x_t] + b_C)     candidate    — the new content
+C_t = f_t ⊙ C_{t-1} + i_t ⊙ C̃_t            cell update  — the additive path
+o_t = σ(W_o · [h_{t-1}, x_t] + b_o)        output gate  — what to expose
+h_t = o_t ⊙ tanh(C_t)                      hidden state
+```
+
+**Why this fixes vanishing gradients.** The cell update is *additive*: `∂C_t/∂C_{t-1} = f_t`. If the forget gate stays near 1, the gradient flows back through many steps essentially unattenuated — there is no repeated matrix multiplication on the cell path. This is the same trick as a residual connection, discovered for sequences two decades earlier.
+
+```python
+lstm = nn.LSTM(
+    input_size=300,
+    hidden_size=512,
+    num_layers=2,
+    batch_first=True,
+    dropout=0.3,          # applied BETWEEN layers only, not across time steps
+    bidirectional=False,
+)
+# output: (batch, seq_len, hidden)   h_n, c_n: (num_layers, batch, hidden)
+output, (h_n, c_n) = lstm(embedded)
+```
+
+**Initialize the forget-gate bias to 1.** At initialization the gates sit near 0.5, so the cell state halves at every step and long-range gradient still decays. Biasing the forget gate positive makes the network default to *remembering*, and it learns to forget where useful. This is a small change with a large effect on convergence, and naming it is a strong interview signal.
+
+```python
+for name, param in lstm.named_parameters():
+    if 'bias_ih' in name or 'bias_hh' in name:
+        n = param.size(0)
+        param.data[n // 4 : n // 2].fill_(1.0)   # PyTorch gate order: i, f, g, o
+```
+
+---
+
+## GRU
+
+The GRU merges the forget and input gates into a single **update gate** and drops the separate cell state.
+
+```
+z_t = σ(W_z · [h_{t-1}, x_t])                update gate — interpolation weight
+r_t = σ(W_r · [h_{t-1}, x_t])                reset gate  — how much past to use
+h̃_t = tanh(W · [r_t ⊙ h_{t-1}, x_t])         candidate
+h_t = (1 - z_t) ⊙ h_{t-1} + z_t ⊙ h̃_t        convex blend of old and new
+```
+
+| | LSTM | GRU |
+|---|---|---|
+| Gates | 3 (forget, input, output) | 2 (update, reset) |
+| State | Separate cell + hidden | Hidden only |
+| Parameters | ~4 × (d_in + d_h) × d_h | ~3 × (d_in + d_h) × d_h (**25% fewer**) |
+| Speed | Slower | ~20–30% faster |
+| Typical edge | Long sequences, large data | Small data, tight compute |
+
+Empirically the two are close, and which wins is task-dependent rather than principled. The defensible interview answer: try GRU first because it is cheaper and trains faster; move to LSTM if the task has long dependencies and you have the data to support the extra parameters.
+
+---
+
+## Bidirectional and Stacked RNNs
+
+**Bidirectional** runs one RNN forward and another backward, concatenating the states, so every position sees both left and right context. It typically gives a solid accuracy gain on classification and tagging — but it requires the **entire sequence up front**, so it is unusable for streaming, real-time transcription, or autoregressive generation. That constraint is the interview point, not the accuracy number.
+
+**Stacking** layers lets lower layers capture local patterns and higher layers capture longer-range structure. Two to four layers is the practical range; beyond that, returns diminish and optimization gets harder without residual connections.
+
+```python
+nn.LSTM(input_size=300, hidden_size=256, num_layers=3,
+        bidirectional=True, batch_first=True, dropout=0.3)
+# output width is 2 × hidden_size = 512 because directions are concatenated
+```
+
+---
+
+## Seq2Seq and the Bottleneck
+
+The encoder-decoder architecture maps an input sequence to an output sequence of a different length — translation, summarization, speech recognition.
+
+```
+Encoder RNN  →  final hidden state (the "context vector")  →  Decoder RNN
+```
+
+The problem is stated in one sentence: **the entire input must be compressed into one fixed-size vector.** For a 5-word sentence that is fine; for a 50-word one, information is lost, and translation quality measurably degrades as source length grows. This bottleneck is the direct motivation for attention.
+
+**Teacher forcing** trains the decoder on ground-truth previous tokens rather than its own predictions. It speeds convergence dramatically, but creates **exposure bias**: at inference the model consumes its own outputs, a distribution it never trained on, so one early mistake compounds. Scheduled sampling — mixing in the model's own predictions with increasing probability — is the classic partial mitigation.
+
+**Decoding** is a separate decision from training. Greedy decoding takes the argmax at each step and is fast but myopic. **Beam search** keeps the `k` highest-probability partial sequences and usually improves quality on translation; it needs length normalization, since raw sequence probability decreases monotonically with length and would otherwise favor short outputs.
+
+---
+
+## Attention: The Fix That Became the Architecture
+
+Attention removed the bottleneck by letting the decoder look back at *every* encoder state, weighted by relevance to the current decoding step.
+
+```
+score(s_t, h_i)  →  α_ti = softmax_i(score)  →  context_t = Σ_i α_ti · h_i
+```
+
+| Variant | Score function | Note |
+|---|---|---|
+| **Additive** (Bahdanau, 2014) | `vᵀ tanh(W₁s + W₂h)` | A small MLP; works when dimensions differ |
+| **Multiplicative** (Luong, 2015) | `sᵀ W h` or `sᵀh` | Cheaper; one matmul |
+| **Scaled dot-product** (2017) | `sᵀh / √d_k` | The transformer's; scaling keeps softmax out of saturation |
+
+Two things followed. First, quality on long sequences improved sharply, because there is no longer a fixed-size summary. Second — and this is the historically important part — the attention weights turned out to carry most of the useful signal, which raised the question the transformer answered: **if attention does the work, is the recurrence needed at all?** Removing it made the whole sequence parallelizable during training, which is what unlocked training at scale.
+
+---
+
+## RNNs vs Transformers in Practice
+
+| Dimension | RNN / LSTM | Transformer |
+|---|---|---|
+| Training parallelism | Sequential in `T` — cannot parallelize across time | Fully parallel across positions |
+| Complexity per layer | `O(T · d²)` | `O(T² · d)` — quadratic in length |
+| Path length between distant tokens | `O(T)` | `O(1)` |
+| Memory at inference | `O(1)` — fixed state | `O(T)` — KV cache grows |
+| Long sequences (T ≫ d) | Cheaper | Expensive without sparse/linear attention |
+| Small datasets | Often competitive | Data-hungry |
+| Streaming / real-time | Natural fit | Needs windowing or a cache |
+
+**When an RNN is still the right choice**: strict streaming with unbounded input and constant memory (real-time speech, sensor telemetry, anomaly detection on event streams); very long sequences where `T² ` attention is prohibitive; small labeled datasets where a transformer overfits; and tight edge deployments where an `O(1)`-state model beats a growing KV cache. State-space models (S4, Mamba) are the modern revival of exactly this argument — recurrent-style linear scaling with much better long-range modeling.
+
+---
+
+## Practical Training Notes
+
+**Padding and masking.** Batches contain variable-length sequences, so shorter ones are padded. Feeding padding through the RNN corrupts the final hidden state and pollutes the loss. Use packed sequences, and mask the loss:
+
+```python
+from torch.nn.utils.rnn import pack_padded_sequence, pad_packed_sequence
+
+packed = pack_padded_sequence(embedded, lengths.cpu(), batch_first=True, enforce_sorted=False)
+packed_out, (h_n, c_n) = lstm(packed)          # h_n now reflects each sequence's TRUE last step
+output, _ = pad_packed_sequence(packed_out, batch_first=True)
+
+loss_fn = nn.CrossEntropyLoss(ignore_index=PAD_IDX)   # exclude padding from the loss
+```
+
+Without packing, `h_n` is the state after consuming trailing `<pad>` tokens — a genuinely common and hard-to-spot bug that quietly caps accuracy.
+
+**Dropout across time.** PyTorch's `dropout` argument applies *between layers*, not between time steps, and it is silently ignored when `num_layers=1`. Applying independent dropout at each time step is harmful — it resamples the mask every step and destroys the memory the recurrence is meant to carry. Variational dropout (the same mask at every step) is the correct form when you want recurrent regularization.
+
+**Gradient clipping is not optional.** Unlike transformers, where it is good hygiene, RNNs genuinely explode without it. Clip global norm at 1.0–5.0.
+
+**Sort or bucket by length.** Batching sequences of wildly different lengths wastes compute on padding. Length-bucketed batching often gives a 2–3x throughput win for free.
+
+---
+
+## Interview Q&A
+
+#### Why do vanilla RNNs fail on long sequences, and how does an LSTM fix it?
+
+The gradient from step `T` back to step `1` is a product of `T` Jacobians, each containing `W_hh` and the `tanh` derivative. Since `tanh' ≤ 1` and typically well below it, and `W_hh`'s singular values are rarely exactly 1, that product shrinks or grows exponentially in sequence length. Shrinking is the common case: early steps receive effectively no learning signal, so the model only learns short-range dependencies.
+
+The LSTM adds a cell state updated **additively**: `C_t = f_t ⊙ C_{t-1} + i_t ⊙ C̃_t`. The gradient along that path is `∂C_t/∂C_{t-1} = f_t`, an elementwise multiply by a learned gate rather than a repeated matrix multiplication. With the forget gate near 1, gradients flow back over hundreds of steps largely intact. It is the same mechanism as a residual connection — give the gradient an uninterrupted highway.
+
+#### LSTM or GRU — how do you choose?
+
+GRU has two gates instead of three and no separate cell state, so roughly 25% fewer parameters and 20–30% faster training. LSTM's extra output gate gives finer control over what is exposed versus stored, which tends to help on long sequences with lots of data.
+
+In practice the accuracy difference is small and task-dependent, so I'd start with GRU for the cheaper iteration loop and switch to LSTM if I have long dependencies and enough data to support the extra capacity. What I would not do is claim one is universally better — the literature does not support that, and the honest answer is that it is an empirical choice.
+
+#### What is the seq2seq bottleneck, and how did attention solve it?
+
+In a basic encoder-decoder, the encoder compresses the whole input into one fixed-size context vector. Capacity is constant while input length grows, so information is lost and translation quality degrades measurably with source length.
+
+Attention removes the constraint: the decoder computes a relevance score between its current state and *every* encoder hidden state, softmaxes those into weights, and takes a weighted sum. Each decoding step gets a context vector tailored to what it currently needs, so nothing has to be compressed away. The follow-on insight — that attention was doing the heavy lifting and recurrence could be dropped entirely — is what produced the transformer, and with it full training parallelism.
+
+#### What is teacher forcing and what problem does it create?
+
+During training, the decoder is fed the ground-truth previous token rather than its own prediction. This makes training much faster and more stable, since the decoder never has to recover from its own early mistakes while the model is still random.
+
+The problem is **exposure bias**: at inference there is no ground truth, so the model consumes its own outputs — a distribution it never saw in training. One wrong token puts it in an unfamiliar state, and errors compound over the sequence. Scheduled sampling (gradually mixing in the model's own predictions during training) and sequence-level objectives are the standard mitigations, though modern practice largely sidesteps it by training at scale on next-token prediction.
+
+#### When would you use a bidirectional RNN, and when can't you?
+
+Use it whenever the full sequence is available before you need an output and both directions carry signal — text classification, named entity recognition, POS tagging, offline speech transcription. Knowing that a word appears before "Inc." helps classify it, and only the backward pass sees that.
+
+You cannot use it for anything causal or streaming: real-time transcription, autoregressive generation, or online anomaly detection, because the backward pass requires future tokens that do not exist yet. That constraint — not the accuracy difference — is what determines the choice.
+
+#### Why do transformers beat RNNs, and when do RNNs still win?
+
+Two reasons. **Parallelism**: an RNN's step `t` depends on `t-1`, so training cannot be parallelized across time; a transformer processes all positions simultaneously, which is what made training on internet-scale data feasible. **Path length**: information between two distant tokens traverses `O(T)` steps in an RNN, with degradation at each, versus `O(1)` through attention.
+
+RNNs still win when `T` is very large, because attention is `O(T²)` while recurrence is linear; when inference memory must be constant, since the KV cache grows with context; in true streaming settings with unbounded input; and on small datasets where transformers overfit. State-space models like Mamba are a direct modern attempt to keep the linear scaling and constant state while fixing the long-range weakness.
+
+#### Your LSTM's validation accuracy plateaus well below expectations. How do you debug it?
+
+I'd check the mechanical bugs before touching the architecture, because they're common and silent:
+1. **Padding handling** — is the model consuming `<pad>` tokens into its final hidden state? Without `pack_padded_sequence`, `h_n` reflects padding, not the real last token. Is the loss masked with `ignore_index`?
+2. **Gradient clipping** — missing clipping shows up as loss spikes; check whether the run is silently diverging and recovering.
+3. **Can it overfit a single batch?** If not, the bug is in the code, not the hyperparameters.
+4. **Sequence truncation** — is the max length cutting off the part of the input that carries the label?
+5. **Forget-gate bias** — initialized to 0 means the cell state halves each step and long-range memory never forms.
+
+Then the modeling questions: are the embeddings pretrained or learned from scratch on too little data, is the sequence long enough to need attention, and is a bidirectional or stacked variant warranted.
+
+#### What is truncated BPTT and what does it cost you?
+
+Full BPTT unrolls the entire sequence and backpropagates through all of it, so memory scales with sequence length and long sequences become infeasible. Truncated BPTT backpropagates only `k` steps back, carrying the hidden state forward across chunks but detaching the gradient at chunk boundaries.
+
+The cost is that the model can never learn a dependency longer than `k` steps, because no gradient signal crosses the boundary. So `k` is a direct cap on the range of learnable dependencies, and choosing it means estimating how far back the relevant context actually sits — a modeling decision, not just a memory knob.
+
+---
+
+## Common Pitfalls
+
+| Pitfall | Why it hurts | Fix |
+|---|---|---|
+| Not packing padded sequences | Final hidden state reflects `<pad>` tokens, silently capping accuracy | `pack_padded_sequence` / `pad_packed_sequence` |
+| Unmasked loss over padding | Model is rewarded for predicting padding | `CrossEntropyLoss(ignore_index=PAD_IDX)` |
+| No gradient clipping | RNNs genuinely explode; loss goes NaN | `clip_grad_norm_(..., 1.0)` |
+| Forget-gate bias left at 0 | Cell state decays by half each step; long memory never forms | Initialize forget-gate bias to 1 |
+| `dropout=` with `num_layers=1` | Silently does nothing — PyTorch applies it between layers | Stack layers, or apply dropout explicitly |
+| Independent dropout per time step | Destroys the recurrent memory being learned | Variational dropout (same mask across time) |
+| Bidirectional model for a streaming task | Requires future tokens that do not exist at inference | Unidirectional, or windowed lookahead |
+| Beam search without length normalization | Sequence probability shrinks with length, so short outputs win | Divide by length, or use a length penalty |
+| Batching wildly different lengths | Most compute spent on padding | Length-bucketed batching |
+| Reaching for an RNN on a modern NLP task | Transformers dominate where data and parallelism exist | Use a pretrained transformer unless streaming or tiny data argues otherwise |
+
+---
+
+## Related Topics
+
+- [Transformers](./intro_transformers.md)
+- [Neural Network Training](./intro_neural_network_training.md)
+- [Applied Deep Learning Roadmap](./intro_applied_deep_learning.md)
+- [Time Series & Forecasting](../classical_ml/intro_time_series.md)
+- [LLM Fundamentals](../ai_genai/intro_llm_fundamentals.md)
+- [LLM Inference Optimization](../ai_genai/intro_llm_inference_optimization.md)
+- [PyTorch](../frameworks/intro_pytorch.md)
+- [Deep Learning Overview](./README.md)

--- a/docs/take-home-projects.md
+++ b/docs/take-home-projects.md
@@ -1,0 +1,281 @@
+# ML Take-Home Projects and Case Studies
+
+The take-home is the highest-variance stage of an ML loop. Candidates with strong fundamentals routinely score poorly on it, not because the modeling was wrong but because they optimized the wrong thing — chasing an extra point of AUC while shipping a notebook nobody can run, no baseline to compare against, and no statement of what they would do next.
+
+This guide covers what reviewers actually score, how to budget your time, the structure that reads well, and the presentation round that usually follows.
+
+---
+
+## Table of Contents
+1. [What Reviewers Actually Score](#what-reviewers-actually-score)
+2. [Time Budget](#time-budget)
+3. [Repository Structure](#repository-structure)
+4. [The README Is the Deliverable](#the-readme-is-the-deliverable)
+5. [Modeling Approach](#modeling-approach)
+6. [Common Take-Home Types](#common-take-home-types)
+7. [The Follow-Up Presentation](#the-follow-up-presentation)
+8. [Scope and Boundaries](#scope-and-boundaries)
+9. [Self-Review Checklist](#self-review-checklist)
+10. [Common Pitfalls](#common-pitfalls)
+11. [Related Topics](#related-topics)
+
+---
+
+## What Reviewers Actually Score
+
+Most rubrics weight roughly like this. Note where accuracy sits.
+
+| Dimension | Weight | What earns the marks |
+|---|---|---|
+| **Problem framing** | High | Restated the business problem, chose a metric and justified it, defined success |
+| **Data understanding** | High | Found the leakage, the imbalance, the duplicates, the temporal structure |
+| **Methodology soundness** | High | Valid splits, a real baseline, honest evaluation, no leakage |
+| **Communication** | High | README a stranger can follow; conclusions stated plainly |
+| **Reproducibility** | Medium-high | Runs end to end from a clean checkout |
+| **Code quality** | Medium | Readable, structured, tested where it matters |
+| **Model performance** | **Low-medium** | Reasonable; the gap between 0.85 and 0.87 rarely decides anything |
+| **Production thinking** | Medium | How it would deploy, monitor, fail, and be retrained |
+
+The single most common mis-calibration is spending 80% of the time on the model and 20% on everything else. Reviewers can see modeling ability from a clean pipeline with a well-chosen baseline; they cannot recover framing, honesty, or communication from a high score.
+
+**What gets a submission rejected outright**, regardless of accuracy: data leakage that inflates results, a random split on temporal data, code that does not run, no baseline, and a metric that does not match the stated problem.
+
+---
+
+## Time Budget
+
+If the brief says "about 4 hours," treat that as a real constraint. Reviewers compare submissions against the stated budget, and a 30-hour submission signals poor prioritization as much as it signals effort — it also disadvantages candidates who respected the limit, which reviewers notice.
+
+For a nominal 4–6 hours:
+
+| Phase | Share | Output |
+|---|---|---|
+| Understand the problem and data | 20% | Framing, metric choice, data quirks found |
+| Baseline end to end | 15% | A trivial model, scored, that the pipeline runs through |
+| Feature work and modeling | 30% | One or two real iterations with a rationale |
+| Evaluation and error analysis | 15% | Slices, confusion, where it fails and why |
+| Write-up and cleanup | 20% | README, structure, reproducibility |
+
+**Build the baseline before the good model.** A majority-class predictor, a simple heuristic, or a logistic regression gives you an end-to-end pipeline within the first hour and a number every later result is measured against. Candidates who skip it often discover at hour five that their pipeline has a bug, with nothing to compare against.
+
+If you run out of time, say so explicitly in the README with what you would have done. That reads as prioritization. Silence reads as not knowing.
+
+---
+
+## Repository Structure
+
+Structure signals engineering maturity before a reviewer reads a line of logic.
+
+```
+churn-prediction/
+├── README.md                  ← the deliverable; write it first, refine last
+├── requirements.txt           ← pinned versions
+├── Makefile                   ← make setup / make train / make evaluate
+├── data/
+│   ├── raw/                   ← immutable, gitignored
+│   └── processed/             ← generated, gitignored
+├── notebooks/
+│   └── 01_exploration.ipynb   ← EDA only, clearly labeled as exploratory
+├── src/
+│   ├── data.py                ← loading and splitting
+│   ├── features.py            ← transformations (importable, testable)
+│   ├── train.py               ← trains and saves a model
+│   └── evaluate.py            ← metrics, slices, plots
+├── tests/
+│   └── test_features.py       ← a few tests on the transformations that matter
+└── reports/
+    └── figures/
+```
+
+Two things reviewers check immediately and that cost you nothing:
+
+- **Does it run?** Clone into a fresh virtualenv, follow your own README literally, and run it. Absolute paths, an undeclared dependency, or a missing data step are the most common reasons a submission scores badly for reasons unrelated to skill.
+- **Is logic in importable modules?** A single 900-cell notebook cannot be tested, reviewed, or reused. Keep exploration in a notebook and put the pipeline in `src/`.
+
+---
+
+## The README Is the Deliverable
+
+Most reviewers spend 10–15 minutes on a submission, and much of it in the README. Write it for someone who will not run your code.
+
+A structure that works:
+
+```markdown
+# <Problem> — Approach and Results
+
+## Problem framing
+What I understood the task to be, the metric I optimized, and why that metric
+fits the stated business context.
+
+## Data
+Size, shape, target balance. What I found: leakage risks, duplicates, missingness
+patterns, temporal structure. What I did about each.
+
+## Approach
+Baseline first, then what I tried and why. Alternatives I considered and rejected,
+with reasons.
+
+## Results
+| Model | PR-AUC | Recall @ 80% precision | Notes |
+|---|---|---|---|
+| Majority baseline | 0.031 | 0.00 | Prevalence floor |
+| Logistic regression | 0.284 | 0.19 | Interpretable reference |
+| Gradient boosting | 0.412 | 0.34 | Final |
+
+## Error analysis
+Where it fails, on which segments, and my hypothesis for why.
+
+## Assumptions and limitations
+Stated plainly. This section builds more trust than the results table.
+
+## What I'd do with more time
+Ranked by expected value, not by what is interesting.
+
+## How to run
+Exact commands, verified from a clean checkout.
+```
+
+Two sections carry disproportionate weight. **Assumptions and limitations** is where reviewers look for intellectual honesty — a candidate who names the weaknesses of their own work is one who can be trusted with an ambiguous problem. **What I'd do next**, ranked by expected value, demonstrates prioritization, which is most of senior ML work.
+
+---
+
+## Modeling Approach
+
+**Framing before fitting.** Write down the prediction target, the unit of prediction, when the prediction would be made in production, and what information is available at that moment. That last question is what prevents leakage, and stating it explicitly is worth marks by itself.
+
+**Choose the metric from the cost structure.** Accuracy on an imbalanced problem is an immediate red flag. Ask what a false positive costs versus a false negative, then pick accordingly — PR-AUC and recall at a fixed precision for rare-event problems, calibration if scores drive decisions, MAE versus RMSE depending on outlier treatment. Say why in one sentence.
+
+**Split before you look.** Fit every transformation — scalers, imputers, target encoders — inside a pipeline on the training fold only. If the data is temporal, split by time; if entities repeat (users, sessions, patients), split by group. A random split on temporal or grouped data is the most common disqualifying error in take-homes, and it produces suspiciously good numbers that reviewers recognize on sight.
+
+```python
+from sklearn.pipeline import Pipeline
+from sklearn.compose import ColumnTransformer
+
+# Everything stateful lives inside the pipeline, so CV can never leak
+pipeline = Pipeline([
+    ("prep", ColumnTransformer([
+        ("num", numeric_pipeline, numeric_cols),
+        ("cat", categorical_pipeline, categorical_cols),
+    ])),
+    ("model", GradientBoostingClassifier(random_state=42)),
+])
+```
+
+**Error analysis beats one more model.** Twenty minutes examining where the model fails — which segments, which feature ranges, what the false positives have in common — produces better material than another hour of hyperparameter search. It is also the part that transfers directly into the presentation round.
+
+**Seed everything and state the variance.** Report `mean ± std` across folds rather than a single number. A candidate who reports 0.412 ± 0.03 is more credible than one who reports 0.4118.
+
+---
+
+## Common Take-Home Types
+
+| Type | Real test | Where candidates lose marks |
+|---|---|---|
+| **Tabular prediction** | Framing, leakage detection, metric choice | Random split on temporal data; accuracy on imbalanced target |
+| **Messy data cleaning** | Judgment under ambiguity | Silently dropping rows; not documenting decisions |
+| **NLP classification** | Sensible baseline before transformers | Fine-tuning BERT without a TF-IDF baseline to justify it |
+| **Recommendation** | Evaluation design | Random split instead of temporal; ignoring cold start |
+| **Time series forecasting** | Validation strategy | Any shuffling; no seasonal-naive baseline |
+| **Build a small service** | Engineering practice | No tests, no error handling, no input validation |
+| **RAG / LLM feature** | Evaluation of a non-deterministic system | No eval set; "looks good" as the evidence |
+| **Open-ended analysis** | Prioritization and communication | Exhaustive EDA with no conclusion |
+
+Two type-specific notes worth knowing. For **NLP**, a TF-IDF plus linear model baseline takes ten minutes and makes any subsequent transformer result meaningful; skipping it is a common and avoidable loss. For **RAG or LLM take-homes**, the whole test is usually whether you build an evaluation harness at all — 20 or 30 labeled question-answer pairs with retrieval recall and answer accuracy measured separately outweighs any amount of prompt polish.
+
+---
+
+## The Follow-Up Presentation
+
+Most take-homes are followed by a 30–45 minute discussion. It is a real round with its own score, and it is where a mid-tier submission can be rescued or a strong one undermined.
+
+**Structure a 10-minute walkthrough**: problem framing and metric choice (2 min), data findings (2 min), approach and baseline comparison (3 min), results and error analysis (2 min), limitations and next steps (1 min). Lead with framing, not with the model.
+
+**Questions to expect:**
+- "Why that metric?" — have the cost reasoning ready.
+- "Why that model, and what else did you consider?"
+- "What was your baseline, and how much did the model actually add over it?"
+- "Where does it fail?" — never answer "I'm not sure"; you did the error analysis.
+- "How would you deploy this?" — features at serving time, latency, monitoring, retraining.
+- "What would break at 100x the data?"
+- "What did you not have time to do?"
+- "What would you do differently?"
+
+**Defend and concede appropriately.** If a reviewer challenges a choice you thought through, explain the reasoning and the alternative you rejected. If they identify a genuine mistake, acknowledge it directly and say what you would change — reviewers frequently probe a known weakness specifically to see whether you will defend the indefensible. Conceding a real error scores better than defending it.
+
+**Know your numbers.** Dataset size, class balance, baseline score, final score, and runtime. Fumbling your own results undermines everything else.
+
+---
+
+## Scope and Boundaries
+
+A few boundary questions come up often enough to answer here.
+
+**Clarifying questions are usually welcome.** One concise email asking about an ambiguous target definition or an unclear evaluation criterion signals engagement. Three rounds of questions signal an inability to act under ambiguity. If nobody responds, state your assumption in the README and proceed — that is the correct behavior, and reviewers score it well.
+
+**Going over the stated time** is a real negative, not the neutral it feels like. If you spent longer, do not claim otherwise; say what you did within the budget and mark clearly anything added afterward.
+
+**On using AI assistance**: follow whatever the brief says. If it is silent, use it as you would at work and be prepared to explain every line — the presentation round exposes code you cannot account for very quickly. Where a brief asks you to disclose usage, disclose it; being caught misrepresenting it ends the process regardless of the work's quality.
+
+**On external data and pretrained models**: allowed unless the brief forbids it, but justify the choice and account for the added complexity. A pretrained model that adds two points over a simple baseline while tripling inference cost is a tradeoff worth discussing rather than an automatic win.
+
+---
+
+## Self-Review Checklist
+
+Run through this before submitting.
+
+**Reproducibility**
+- [ ] Cloned to a fresh directory, new virtualenv, followed the README literally — it runs
+- [ ] Dependencies pinned; no absolute paths; seeds set
+- [ ] Large data and artifacts gitignored, with instructions for obtaining them
+
+**Methodology**
+- [ ] A baseline exists and is reported alongside the final model
+- [ ] Split respects time and entity structure
+- [ ] Every transformation is fit inside the pipeline on training data only
+- [ ] Metric matches the stated business problem, with the reason given
+- [ ] Results reported as mean ± std, not a single decimal-heavy number
+
+**Communication**
+- [ ] README answers: what problem, what approach, what result, what next
+- [ ] Assumptions and limitations stated explicitly
+- [ ] Next steps ranked by expected value
+- [ ] A reader who never runs the code understands the conclusion
+
+**Code**
+- [ ] Pipeline logic in importable modules, not only in notebooks
+- [ ] Notebooks are clean and labeled as exploratory
+- [ ] A few tests on the transformations that matter
+- [ ] No commented-out dead code, no leftover debug prints
+
+---
+
+## Common Pitfalls
+
+| Pitfall | Why it costs you | Fix |
+|---|---|---|
+| No baseline | Results are uninterpretable; reviewers cannot judge the gain | Trivial baseline first, reported alongside |
+| Random split on temporal data | Leaks the future; disqualifying | Time-based split, with a gap for label latency |
+| Preprocessing fit before the split | Leaks test statistics into training | Fit everything inside a `Pipeline` |
+| Accuracy on an imbalanced target | Signals a fundamental gap | PR-AUC, recall at fixed precision, and say why |
+| All logic in one notebook | Cannot be tested, reviewed, or reused | Modules in `src/`, notebook for EDA only |
+| README written last, in five minutes | It is the most-read artifact | Draft it first, refine at the end |
+| Chasing accuracy over everything else | Weighted lowest in most rubrics | Spend the time on framing, evaluation, write-up |
+| Massively exceeding the stated time | Signals poor prioritization | Respect the budget; list what you cut |
+| No error analysis | Loses the strongest presentation material | Twenty minutes on where and why it fails |
+| Unstated assumptions | Reads as not noticing the ambiguity | An explicit assumptions section |
+| Submission never run from a clean checkout | The most common avoidable failure | Fresh clone, fresh venv, follow your own README |
+
+---
+
+## Related Topics
+
+- [Behavioral and Project Deep-Dive Guide](./behavioral-interview-guide.md)
+- [2026 Interview Roadmap](./2026-interview-roadmap.md)
+- [Study Pattern](./study-pattern.md)
+- [Model Evaluation and Metrics](../classical_ml/intro_model_evaluation.md)
+- [Ensemble Methods](../classical_ml/intro_ensemble_methods.md)
+- [ML Coding Challenges](../coding_challenges/ml_coding_challenges.md)
+- [ML/AI Project Structure](../project_setup/intro_project_structure.md)
+- [GitHub Project Setup](../project_setup/intro_github_project_setup.md)
+- [ML System Design Framework](../system_design/README.md)

--- a/frameworks/README.md
+++ b/frameworks/README.md
@@ -210,6 +210,22 @@ Choose pgvector if you already use PostgreSQL and have < 10M vectors. Choose a d
 
 ---
 
+## Guides in This Track
+
+Every guide in `frameworks/`. Start with the overview above, then work through these.
+
+- [FastAPI — Production-Grade AI Backend Engineering](./intro_fastapi.md)
+- [Hugging Face Guide](./intro_huggingface.md)
+- [LangChain Guide](./intro_langchain.md)
+- [Ollama — Run LLMs Locally](./intro_ollama.md)
+- [Pydantic — Data Validation for AI Systems](./intro_pydantic.md)
+- [Python for AI Engineering (2026 Edition)](./intro_python_for_ai.md)
+- [PyTorch Guide](./intro_pytorch.md)
+- [Unsloth — Fast LoRA Fine-Tuning](./intro_unsloth.md)
+- [vLLM — High-Throughput LLM Serving](./intro_vllm.md)
+
+---
+
 ## References
 
 - [Ollama Documentation](https://ollama.com/docs)

--- a/index.html
+++ b/index.html
@@ -886,13 +886,14 @@ const TRACKS = [
   {
     id: 'docs', phase: 'start', icon: '🗺️', color: '#38bdf8',
     title: 'Roadmap & Study Guides',
-    desc: '2026 interview focus areas, role-by-role study plans, behavioral and project deep-dive prep, and curated resources.',
+    desc: '2026 interview focus areas, role-by-role study plans, behavioral, take-home and project deep-dive prep, and curated resources.',
     files: [
       { label: '2026 Roadmap', path: 'docs/2026-interview-roadmap.md' },
       { label: '2026 Interview Questions', path: 'docs/interview_questions_2026.md' },
       { label: 'Additional Questions', path: 'docs/2026-additional-questions.md' },
       { label: 'Study Pattern', path: 'docs/study-pattern.md' },
       { label: 'Behavioral & Project Deep-Dive', path: 'docs/behavioral-interview-guide.md' },
+      { label: 'Take-Home Projects', path: 'docs/take-home-projects.md' },
       { label: 'Resources & References', path: 'docs/resources-and-references.md' },
     ]
   },
@@ -915,10 +916,11 @@ const TRACKS = [
   {
     id: 'deep_learning', phase: 'foundations', icon: '🧠', color: '#10b981',
     title: 'Deep Learning',
-    desc: 'Transformer architecture, attention, training dynamics and optimization, computer vision, and fine-tuning.',
+    desc: 'Sequence models, transformer architecture, attention, training dynamics and optimization, computer vision, and fine-tuning.',
     files: [
       { label: 'Overview', path: 'deep_learning/README.md' },
       { label: 'Applied Deep Learning', path: 'deep_learning/intro_applied_deep_learning.md' },
+      { label: 'Sequence Models (RNN/LSTM/GRU)', path: 'deep_learning/intro_sequence_models.md' },
       { label: 'Transformers', path: 'deep_learning/intro_transformers.md' },
       { label: 'Computer Vision', path: 'deep_learning/intro_computer_vision.md' },
       { label: 'Fine-Tuning', path: 'deep_learning/intro_fine_tuning.md' },
@@ -928,11 +930,12 @@ const TRACKS = [
   {
     id: 'ai_genai', phase: 'genai', icon: '🤖', color: '#8b5cf6',
     title: 'AI & GenAI',
-    desc: 'LLM fundamentals, prompting, RAG, embeddings, vector DBs, inference optimization, LLMOps, agents, MCP, LangChain, and the Claude API.',
+    desc: 'LLM fundamentals, prompting, context engineering, RAG, embeddings, vector DBs, inference optimization, LLMOps, agents, MCP, and the Claude API.',
     files: [
       { label: 'Agentic AI Engineer Roadmap', path: 'ai_genai/intro_agentic_ai_engineering_roadmap.md' },
       { label: 'LLM Fundamentals', path: 'ai_genai/intro_llm_fundamentals.md' },
       { label: 'Prompt Engineering', path: 'ai_genai/intro_prompt_engineering.md' },
+      { label: 'Context Engineering', path: 'ai_genai/intro_context_engineering.md' },
       { label: 'Structured Outputs', path: 'ai_genai/intro_structured_outputs.md' },
       { label: 'Intro to RAG', path: 'ai_genai/intro_rag.md' },
       { label: 'RAG Engineering', path: 'ai_genai/intro_rag_engineering.md' },
@@ -977,10 +980,11 @@ const TRACKS = [
   {
     id: 'mlops', phase: 'production', icon: '🔧', color: '#f59e0b',
     title: 'MLOps',
-    desc: 'MLflow, feature stores, model serving, explainability, data quality, monitoring, and LLM evaluation.',
+    desc: 'MLflow, CI/CD for ML, feature stores, model serving, explainability, data quality, monitoring, and LLM evaluation.',
     files: [
       { label: 'Overview', path: 'mlops/README.md' },
       { label: 'LLMOps / MLOps Engineering', path: 'mlops/intro_llmops_mlops_engineering.md' },
+      { label: 'CI/CD for ML', path: 'mlops/intro_cicd_for_ml.md' },
       { label: 'MLflow', path: 'mlops/intro_mlflow.md' },
       { label: 'Feature Stores', path: 'mlops/intro_feature_stores.md' },
       { label: 'Model Serving', path: 'mlops/intro_model_serving.md' },

--- a/mlops/README.md
+++ b/mlops/README.md
@@ -170,7 +170,7 @@ Rollback:      All traffic → Blue (v1) — instant
 
 ## Feature Stores
 
-A feature store is a centralized repository for storing, versioning, and serving ML features. See [Feature Store Guide](./intro_feature_store.md) for details.
+A feature store is a centralized repository for storing, versioning, and serving ML features. See [Feature Stores](./intro_feature_stores.md) and the [Feature Store Guide](./intro_feature_store.md) for details — the two guides cover the topic from complementary angles.
 
 **Key concepts:**
 - **Online store:** Low-latency feature retrieval for real-time inference (Redis, DynamoDB)
@@ -380,6 +380,25 @@ Training-serving skew occurs when the features used during training are computed
 11. Full rollout: 100% traffic if metrics are stable
 12. Alerting: PagerDuty alerts for degradation
 ```
+
+---
+
+## Guides in This Track
+
+Every guide in `mlops/`. Start with the overview above, then work through these.
+
+- [A/B Testing & Experimentation for ML Systems](./intro_ab_testing.md)
+- [CI/CD for Machine Learning](./intro_cicd_for_ml.md)
+- [Data Quality & Validation](./intro_data_quality.md)
+- [Evaluation and Guardrails for AI Systems](./intro_evaluation_guardrails.md)
+- [Feature Store Guide](./intro_feature_store.md)
+- [Feature Stores](./intro_feature_stores.md)
+- [LLM Evaluation — Testing, Benchmarks & Production Evals](./intro_llm_evaluation.md)
+- [LLMOps and MLOps Engineering](./intro_llmops_mlops_engineering.md)
+- [MLflow: Experiment Tracking, Model Registry, and Deployment](./intro_mlflow.md)
+- [Model Explainability: SHAP, LIME, and Interpretability Techniques](./intro_model_explainability.md)
+- [Model Monitoring Guide](./intro_model_monitoring.md)
+- [Model Serving](./intro_model_serving.md)
 
 ---
 

--- a/mlops/intro_cicd_for_ml.md
+++ b/mlops/intro_cicd_for_ml.md
@@ -1,0 +1,412 @@
+# CI/CD for Machine Learning
+
+Shipping a model is not shipping code. A traditional pipeline validates one artifact — the binary — against tests that are deterministic and fast. An ML pipeline has three coupled artifacts (code, data, model), tests that are statistical rather than binary, and a deploy whose correctness cannot be fully established before real traffic touches it. This guide covers the pipeline, the testing pyramid, the model registry and promotion gates, deployment strategies, and rollback.
+
+---
+
+## Table of Contents
+1. [Why ML CI/CD Is Different](#why-ml-cicd-is-different)
+2. [The Pipeline End to End](#the-pipeline-end-to-end)
+3. [The ML Testing Pyramid](#the-ml-testing-pyramid)
+4. [Model Registry and Promotion Gates](#model-registry-and-promotion-gates)
+5. [Deployment Strategies](#deployment-strategies)
+6. [Rollback](#rollback)
+7. [Continuous Training](#continuous-training)
+8. [Reproducibility Requirements](#reproducibility-requirements)
+9. [A Worked GitHub Actions Pipeline](#a-worked-github-actions-pipeline)
+10. [Maturity Levels](#maturity-levels)
+11. [Interview Q&A](#interview-qa)
+12. [Common Pitfalls](#common-pitfalls)
+13. [Related Topics](#related-topics)
+
+---
+
+## Why ML CI/CD Is Different
+
+| Dimension | Traditional software | Machine learning |
+|---|---|---|
+| Versioned artifacts | Code | Code **+ data + model + features** |
+| Test outcome | Pass / fail, deterministic | Statistical — "AUC ≥ 0.82", threshold-dependent |
+| CI duration | Seconds to minutes | Minutes to hours (training) |
+| Correct at deploy time? | Provable by tests | Only observable under real traffic |
+| Degrades while idle? | No | **Yes** — data drift moves the world under a static model |
+| Rollback unit | Previous binary | Previous model **and** its feature pipeline |
+| Triggers | Code commit | Code commit, **new data**, drift alert, schedule |
+
+The two rows that generate most interview follow-ups: models degrade without anyone touching them, so the pipeline needs triggers other than commits; and a rollback must revert the model *together with* the feature transformations it expects, or you get a fresh skew bug on top of the original problem.
+
+---
+
+## The Pipeline End to End
+
+```
+   commit / new data / drift alert / schedule
+              │
+              ▼
+   ┌──────────────────────┐
+   │ CI: code + data      │  lint, unit tests, schema + distribution checks
+   └──────────┬───────────┘
+              ▼
+   ┌──────────────────────┐
+   │ Train                │  pinned data version, seeded, tracked
+   └──────────┬───────────┘
+              ▼
+   ┌──────────────────────┐
+   │ Evaluate             │  holdout + slices + baseline comparison
+   └──────────┬───────────┘
+              ▼
+   ┌──────────────────────┐
+   │ Register (staging)   │  model + metrics + lineage + signature
+   └──────────┬───────────┘
+              ▼
+   ┌──────────────────────┐
+   │ Gates                │  quality, fairness, latency, size, skew check
+   └──────────┬───────────┘
+              ▼
+   ┌──────────────────────┐
+   │ Deploy: shadow →     │  progressive exposure with automated rollback
+   │ canary → full        │
+   └──────────┬───────────┘
+              ▼
+   ┌──────────────────────┐
+   │ Monitor              │  performance, drift, latency → feeds triggers
+   └──────────────────────┘
+```
+
+The loop closing back on triggers is the part that distinguishes an ML pipeline from a code pipeline. Monitoring is not a dashboard at the end; it is an input to the next run.
+
+---
+
+## The ML Testing Pyramid
+
+Fast and cheap at the bottom, slow and expensive at the top. Run the bottom on every commit.
+
+| Layer | Tests | Runtime | Runs on |
+|---|---|---|---|
+| **Code** | Unit tests on transforms, feature functions, serving handlers | Seconds | Every commit |
+| **Data** | Schema, nullability, ranges, cardinality, volume, freshness, distribution vs baseline | Seconds–minutes | Every commit + every pipeline run |
+| **Model** | Trains without error, beats a baseline, meets thresholds overall **and per slice**, behavioral tests | Minutes–hours | Every model change |
+| **Integration** | Feature pipeline → model → API contract; train/serve parity | Minutes | Pre-deploy |
+| **Deployment** | Smoke test, latency under load, shadow comparison | Minutes | Every deploy |
+
+### Data tests
+
+```python
+import pandas as pd
+
+def validate_training_data(df: pd.DataFrame, baseline_stats: dict) -> list[str]:
+    """Return a list of failures. Empty list means the data is safe to train on."""
+    failures = []
+
+    expected = {"user_id": "int64", "amount": "float64", "category": "object"}
+    for col, dtype in expected.items():
+        if col not in df.columns:
+            failures.append(f"missing column: {col}")
+        elif str(df[col].dtype) != dtype:
+            failures.append(f"{col}: expected {dtype}, got {df[col].dtype}")
+
+    if len(df) < baseline_stats["min_rows"]:
+        failures.append(f"row count {len(df)} below floor {baseline_stats['min_rows']}")
+
+    for col, max_null in baseline_stats["max_null_rate"].items():
+        rate = df[col].isna().mean()
+        if rate > max_null:
+            failures.append(f"{col}: null rate {rate:.3f} exceeds {max_null}")
+
+    # Distribution shift on numeric features — catches semantic changes that pass schema checks
+    for col, ref in baseline_stats["psi_reference"].items():
+        psi = population_stability_index(df[col], ref)
+        if psi > 0.25:
+            failures.append(f"{col}: PSI {psi:.3f} indicates significant shift")
+
+    return failures
+```
+
+A partial load is the sneakiest failure here: the schema is valid, every value is plausible, and only the row count reveals that half the data is missing. Compare volume against the same weekday historically, not a fixed constant, or seasonality generates constant false alarms.
+
+### Model tests beyond an aggregate metric
+
+An aggregate threshold hides the failure that matters. Three additions:
+
+```python
+def evaluate_model(model, X_test, y_test, slices, baseline_metrics, thresholds):
+    results = {"overall": roc_auc_score(y_test, model.predict_proba(X_test)[:, 1])}
+
+    # 1. Per-slice metrics — an overall gain can mask a large regression on a segment
+    for name, mask in slices.items():
+        if mask.sum() >= 100:                       # ignore slices too small to be meaningful
+            results[name] = roc_auc_score(y_test[mask], model.predict_proba(X_test[mask])[:, 1])
+
+    # 2. Never ship a regression against what is already in production
+    regressions = [k for k, v in results.items()
+                   if k in baseline_metrics and v < baseline_metrics[k] - thresholds["tolerance"]]
+
+    # 3. Behavioral tests — invariances and directional expectations, not just accuracy
+    behavioral = run_behavioral_tests(model)        # e.g. raising income must not raise default risk
+    return results, regressions, behavioral
+```
+
+**Behavioral tests** are the ML analogue of unit tests: assert an invariance (prediction unchanged when an irrelevant field changes), a directional expectation (raising a known-protective feature moves the score the right way), or a minimum-functionality case (an obvious fraud pattern is caught). They catch classes of bug that any aggregate metric passes straight over.
+
+---
+
+## Model Registry and Promotion Gates
+
+The registry is the system of record: a versioned model binary plus everything needed to trust, reproduce, and roll it back.
+
+| Stored with every version | Why |
+|---|---|
+| Model artifact + framework version | Reproduce the runtime |
+| Training data version / snapshot ID | Reproduce the inputs |
+| Code commit SHA | Reproduce the logic |
+| Hyperparameters + random seeds | Reproduce the run |
+| Evaluation metrics, overall and per slice | Compare against candidates and production |
+| Input/output signature and schema | Validate at serving; detect contract breaks |
+| Feature pipeline version | **Roll back together with the model** |
+| Stage (`staging` / `production` / `archived`) | Drive promotion |
+
+```python
+import mlflow
+
+with mlflow.start_run() as run:
+    mlflow.log_params({"max_depth": 6, "learning_rate": 0.05, "seed": 42})
+    mlflow.log_metrics({"auc": auc, "pr_auc": pr_auc, **slice_metrics})
+    mlflow.log_dict({"data_version": data_version, "feature_pipeline": fp_version}, "lineage.json")
+    mlflow.sklearn.log_model(model, "model", signature=signature, registered_model_name="churn")
+
+client = mlflow.MlflowClient()
+if passes_all_gates(metrics, baseline):
+    client.transition_model_version_stage("churn", version, stage="Staging")
+```
+
+**Promotion gates** — every one automated, and every one able to block:
+
+1. **Quality**: beats the production model on the primary metric, and does not regress any tracked slice beyond tolerance.
+2. **Baseline sanity**: beats a trivial baseline (majority class, last value, simple heuristic). A model that cannot is not worth operating.
+3. **Fairness**: metric parity across protected segments within policy.
+4. **Operational**: p99 inference latency, memory footprint, artifact size within limits.
+5. **Skew check**: features computed by the serving path match the training path for the same entities.
+6. **Reproducibility**: lineage is complete — a missing data version fails the gate.
+
+Automate the gates; keep a human approval for the final production transition in regulated or high-stakes settings. The gates are what make that approval a review rather than a rubber stamp.
+
+---
+
+## Deployment Strategies
+
+| Strategy | Mechanism | Risk | Cost | Gives you |
+|---|---|---|---|---|
+| **Recreate** | Stop old, start new | High | Low | Nothing — downtime and no fallback |
+| **Blue/green** | Two full environments, flip traffic | Low | 2x infra | Instant rollback |
+| **Canary** | 1% → 5% → 25% → 100%, watching metrics | Low | Low | Graduated real-traffic exposure |
+| **Shadow** | New model scores real traffic; output discarded | **None** | Extra compute | Real-traffic validation with zero user risk |
+| **A/B test** | Random split, measure business metrics | Medium | Low | Causal read on the business outcome |
+| **Multi-armed bandit** | Adaptive traffic to the better arm | Medium | Medium | Faster convergence, less regret |
+
+The sequence that works for a meaningful model change is **shadow → canary → A/B → full**:
+
+- **Shadow** first, because it is the only step that validates on real production traffic at zero user risk. It catches the failures offline evaluation cannot: train/serve skew, latency under real load, unexpected input distributions, and serialization or dependency problems. Compare prediction distributions, not just aggregate metrics.
+- **Canary** next, to expose a small slice of users with automated rollback wired to guardrail metrics.
+- **A/B** if the question is whether the model improves a *business* outcome, which offline metrics only proxy.
+
+```yaml
+# Canary with automated rollback (Argo Rollouts style)
+strategy:
+  canary:
+    steps:
+      - setWeight: 5
+      - pause: {duration: 15m}
+      - analysis:
+          templates: [{templateName: model-health}]   # error rate, p99 latency, prediction drift
+      - setWeight: 25
+      - pause: {duration: 1h}
+      - analysis:
+          templates: [{templateName: model-health}]
+      - setWeight: 100
+```
+
+---
+
+## Rollback
+
+Rollback must be **fast, tested, and complete**.
+
+- **Fast**: a config or traffic-weight change, not a rebuild. Keep the previous version warm — a rollback that requires a 20-minute container build is not a rollback, it is an outage with a plan.
+- **Tested**: rehearse it. An untested rollback path fails exactly when you need it.
+- **Complete**: revert the model **and** its feature pipeline, preprocessing, and configuration together. Reverting only the model artifact while the new feature transformations remain live produces a skew bug that is harder to diagnose than the original problem. This is why the registry stores the feature pipeline version alongside the model.
+
+Automate the trigger where the signal is unambiguous — error rate above threshold, p99 latency breach, prediction distribution shift beyond a bound, or a guardrail business metric dropping. Keep a manual kill switch regardless, since not every failure is one a rule anticipated.
+
+---
+
+## Continuous Training
+
+Retraining is triggered by one of four things, and choosing among them is a real design decision:
+
+| Trigger | When it fits | Watch out for |
+|---|---|---|
+| **Scheduled** | Steady, predictable drift | Retrains when nothing changed; wastes compute |
+| **Performance-based** | Labels arrive fast enough to measure degradation | Useless when labels are delayed weeks |
+| **Drift-based** | Input distribution shift is measurable immediately | Drift does not always mean degradation — verify before acting |
+| **Data-volume** | Enough new labeled data has accumulated | Can retrain on a non-representative recent slice |
+
+Whatever the trigger, an automatically retrained model **goes through the same gates as a manual one**. Auto-retrain plus auto-deploy without gates is how a corrupted upstream table silently becomes a production model. The retraining pipeline should also guard against feedback loops: if the model's own decisions shape which labels you observe (only approved loans get repayment outcomes), naive retraining amplifies its existing bias.
+
+---
+
+## Reproducibility Requirements
+
+An interviewer's favorite probe: *can you reproduce the model that is in production right now?*
+
+Requirements: pinned data snapshot or table version (time-travel via Delta/Iceberg, or an immutable partition); pinned code commit; pinned dependency versions (a lockfile, not a range — a minor scikit-learn bump can change defaults); seeded RNGs for Python, NumPy, and the framework; recorded hardware and framework versions where GPU nondeterminism matters; and the environment captured as a container image digest, not a tag.
+
+Bitwise reproducibility on GPU requires deterministic kernels and costs throughput, so the practical standard is *statistical* reproducibility — retraining yields a model within a small tolerance on the eval set — with full lineage recorded. Say which one you mean; conflating them is a common slip.
+
+---
+
+## A Worked GitHub Actions Pipeline
+
+```yaml
+name: ML Pipeline
+
+on:
+  push: {branches: [main]}
+  schedule: [{cron: '0 2 * * 1'}]          # weekly retrain
+  workflow_dispatch:                        # manual + drift-alert webhook
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: {python-version: '3.11', cache: pip}
+      - run: pip install -r requirements-lock.txt   # locked, not ranged
+      - run: ruff check . && mypy src/
+      - run: pytest tests/unit tests/data -v        # fast layers on every commit
+
+  train:
+    needs: test
+    runs-on: [self-hosted, gpu]
+    steps:
+      - uses: actions/checkout@v4
+      - run: python -m src.train --config configs/prod.yaml --seed 42
+        env:
+          MLFLOW_TRACKING_URI: ${{ secrets.MLFLOW_URI }}
+      - run: python -m src.evaluate --run-id "$MLFLOW_RUN_ID" --compare-to production
+      # evaluate exits non-zero if any gate fails, which fails the job
+
+  deploy_staging:
+    needs: train
+    steps:
+      - run: python -m src.promote --stage Staging
+      - run: python -m src.deploy --env staging --mode shadow --duration 24h
+      - run: python -m src.compare_shadow --fail-on-divergence
+
+  deploy_production:
+    needs: deploy_staging
+    environment: production        # requires human approval in GitHub
+    steps:
+      - run: python -m src.deploy --env prod --strategy canary --auto-rollback
+```
+
+Two details worth calling out in an interview: training runs on a **self-hosted GPU runner** because hosted runners lack GPUs and time out; and the `environment: production` key is what inserts a human approval gate without scripting one.
+
+---
+
+## Maturity Levels
+
+| Level | Training | Deployment | Retraining | Typical signal |
+|---|---|---|---|---|
+| **0 — Manual** | Notebook | Manual copy | Ad hoc, when someone notices | No versioning; "it works on my machine" |
+| **1 — Automated training** | Pipeline script | Manual | Scheduled | Experiments tracked; deploys still hand-run |
+| **2 — Automated deployment** | Pipeline | CI/CD with gates | Triggered | Registry, gates, canary, rollback |
+| **3 — Full CT/CD** | Pipeline | Automated | Drift/performance-triggered | Monitoring feeds retraining automatically |
+
+Most teams sit at level 1 and benefit most from reaching level 2 — the registry, gates, and a tested rollback. Level 3 pays off only with high data velocity and reliable, fast labels; adopting it earlier mostly automates the propagation of mistakes.
+
+---
+
+## Interview Q&A
+
+#### How does CI/CD for ML differ from CI/CD for regular software?
+
+Three structural differences. First, there are **three coupled artifacts** — code, data, and model — so versioning one is insufficient; reproducing a production model requires the data snapshot and feature pipeline version too. Second, **tests are statistical**: instead of assert-equals you have "AUC at least 0.82 and no slice regressing more than 2 points," which means defining thresholds and tolerating variance. Third, **models decay without any change** — data drift degrades a static model, so the pipeline needs triggers beyond commits: schedules, drift alerts, and performance thresholds.
+
+There is also a validation gap: you cannot fully establish a model is correct before real traffic touches it, which is why shadow and canary deployment matter far more here than for a typical service.
+
+#### What gates would you put between training and production?
+
+Automated, and each able to block: (1) the candidate beats the current production model on the primary metric; (2) no tracked slice regresses beyond tolerance — an overall gain can hide a large regression on a segment; (3) it beats a trivial baseline, because a model that cannot is not worth the operational cost; (4) fairness metrics across protected segments stay within policy; (5) operational limits — p99 latency, memory, artifact size; (6) a train/serve skew check comparing features from both paths for the same entities; (7) complete lineage, so a missing data version fails the gate.
+
+In regulated or high-stakes settings I'd keep a human approval for the final production transition, but the automated gates are what turn that approval into a real review rather than a formality.
+
+#### Explain shadow deployment and why it's valuable.
+
+The new model receives a copy of real production traffic and produces predictions that are logged but never returned to users; the existing model continues serving. It is the only validation step with genuinely zero user risk.
+
+Its value is catching what offline evaluation structurally cannot: **train/serve skew** — features computed differently in the serving path; **latency under real load** rather than benchmark conditions; **real input distributions**, including the malformed and edge-case requests that never appear in a clean test set; and **serialization or dependency failures** in the production runtime.
+
+I'd compare prediction *distributions* between old and new, not just aggregate metrics — a shifted distribution with similar aggregate accuracy is a strong signal something is wrong. The cost is running inference twice, which is why it is usually time-boxed rather than permanent.
+
+#### Your newly deployed model is degrading. Walk me through the rollback.
+
+First **stop the bleeding**: shift traffic back to the previous version by config or weight change — seconds, not a rebuild. This is why the previous version stays warm.
+
+Crucially, revert **the model and its feature pipeline together**. Reverting only the artifact while new feature transformations stay live creates a skew bug on top of the original failure, and it is much harder to diagnose. The registry stores the feature pipeline version with the model precisely so this is one atomic action.
+
+Then **diagnose** with the traffic already safe: compare input distributions before and after, check whether an upstream schema changed, look at per-slice metrics to see whether degradation is uniform or concentrated in a segment, and check whether the deployed artifact matches what passed the gates. Finally, **close the loop** — add whatever would have caught this as a gate or monitor, since the same class of failure otherwise recurs.
+
+#### When should retraining be automatic, and when should a human be in the loop?
+
+Automatic retraining fits when data velocity is high, labels arrive quickly and reliably, drift is a routine and well-understood phenomenon, and the gates are strong enough to catch a bad model. Recommendation and demand forecasting typically qualify.
+
+Keep a human in the loop when labels are delayed or noisy (you would be retraining on a signal you cannot yet verify), in regulated domains requiring documented review, when the model's own decisions shape future labels — a feedback loop where naive retraining amplifies existing bias — and when the cost of a bad model is severe relative to the cost of staleness.
+
+The invariant either way: an automatically retrained model passes the **same gates** as a manual one. Auto-retrain with auto-deploy and no gates is how a corrupted upstream table becomes a production model overnight.
+
+#### How do you version data alongside code?
+
+Layered. **Immutable raw data**, append-only and partitioned by ingest date, never mutated — this is the foundation, and mutating raw data destroys reproducibility permanently. **Versioned table formats** (Delta Lake, Iceberg) for curated tables, so "train on the data as of March 1" is a time-travel query rather than an archaeology project. **Snapshot references recorded in the model artifact**, so every training run records exactly which table versions, feature definitions, and code commit produced it. DVC or LakeFS cover file-based assets where table formats do not apply.
+
+The test of whether it actually works: can you reproduce a model trained six months ago from its recorded metadata alone, without asking anyone what they ran?
+
+#### Why aren't aggregate metrics enough as a promotion gate?
+
+Because they average away the failures that matter. A model can improve overall AUC by 2 points while regressing badly on a segment — a minority language, a small region, new users — and the aggregate never shows it, especially when that segment is a small share of the data. That is both a quality failure and, for protected attributes, a fairness one.
+
+So I'd gate on per-slice metrics with a regression tolerance, on comparison against the current production model rather than an absolute threshold, and on **behavioral tests** — invariances and directional expectations that assert properties rather than accuracy. Those catch bug classes any aggregate metric passes straight over, like a model that becomes sensitive to a field that should be irrelevant.
+
+---
+
+## Common Pitfalls
+
+| Pitfall | Why it hurts | Fix |
+|---|---|---|
+| Versioning code but not data | Production models cannot be reproduced | Pin data snapshots; record versions in the artifact |
+| Rolling back the model but not the feature pipeline | Creates a skew bug on top of the original failure | Store and revert them together |
+| Aggregate metrics as the only gate | Hides large regressions on a segment | Per-slice gates with regression tolerance |
+| Auto-retrain with auto-deploy and no gates | A corrupted upstream table becomes a production model | Same gates for automated and manual runs |
+| Dependency ranges instead of a lockfile | A minor library bump silently changes model behavior | Lockfile + container image digest |
+| Rollback path never rehearsed | It fails exactly when it is needed | Test rollback as part of the deploy pipeline |
+| Cold previous version | "Rollback" becomes a 20-minute rebuild | Keep the previous version warm |
+| Fixed row-count thresholds for data checks | Weekly seasonality causes constant false alarms | Compare against the same weekday historically |
+| Training on hosted CI runners | No GPU, and jobs time out | Self-hosted GPU runners for the training job |
+| Deploying straight to 100% | No safe way to observe a regression | Shadow, then canary with automated rollback |
+| Treating drift as automatically requiring retraining | Drift does not always mean degradation | Verify performance impact before triggering |
+
+---
+
+## Related Topics
+
+- [MLOps Overview](./README.md)
+- [MLflow](./intro_mlflow.md)
+- [Model Serving](./intro_model_serving.md)
+- [Model Monitoring](./intro_model_monitoring.md)
+- [Data Quality](./intro_data_quality.md)
+- [A/B Testing](./intro_ab_testing.md)
+- [Feature Stores](./intro_feature_stores.md)
+- [GitHub Actions](../devops/intro_github_actions.md)
+- [Docker](../devops/intro_docker.md)
+- [Kubernetes](../devops/intro_kubernetes.md)
+- [Model Evaluation and Metrics](../classical_ml/intro_model_evaluation.md)

--- a/mlops/intro_feature_store.md
+++ b/mlops/intro_feature_store.md
@@ -2,6 +2,11 @@
 
 A comprehensive guide to feature stores — centralized repositories for storing, versioning, and serving ML features.
 
+> **Related guide:** this track also has [Feature Stores](./intro_feature_stores.md), which covers the same
+> topic from a different angle — point-in-time correctness, when a feature store is and isn't worth it, and
+> common pitfalls. This guide leans toward the motivation, tool comparison, and a Feast walkthrough.
+> Read both if you are preparing the topic for an interview.
+
 ---
 
 ## Table of Contents

--- a/mlops/intro_feature_stores.md
+++ b/mlops/intro_feature_stores.md
@@ -2,6 +2,10 @@
 
 A feature store is a centralized repository for storing, sharing, and serving ML features. It bridges the gap between data engineering and model training/serving, solving the consistency problem between offline training and online inference.
 
+> **Related guide:** this track also has the [Feature Store Guide](./intro_feature_store.md), which covers the
+> same topic with more emphasis on why feature stores exist, a tool comparison, and a Feast walkthrough.
+> This guide leans toward point-in-time correctness, when to adopt one, and common pitfalls.
+
 ---
 
 ## Table of Contents

--- a/project_setup/README.md
+++ b/project_setup/README.md
@@ -24,3 +24,12 @@ is the most common reason good prototypes never ship.
 - Experiment tracking & registries → [MLflow](../mlops/intro_mlflow.md)
 - Production AI engineering → [LLMOps / MLOps Engineering](../mlops/intro_llmops_mlops_engineering.md)
 - Agent architecture → [Agentic AI](../ai_genai/intro_agentic_ai.md)
+
+---
+
+## Guides in This Track
+
+Every guide in `project_setup/`. Start with the overview above, then work through these.
+
+- [How to Set Up a Project on GitHub — Complete Tutorial (2026 Edition)](./intro_github_project_setup.md)
+- [ML / AI Project Folder Structures (2026 Edition)](./intro_project_structure.md)

--- a/system_design/README.md
+++ b/system_design/README.md
@@ -429,6 +429,18 @@ Latency directly impacts user experience (100ms slowdown = 1% drop in conversion
 
 ---
 
+## Guides in This Track
+
+Every guide in `system_design/`. Start with the overview above, then work through these.
+
+- [Backend System Design Interview Guide](./backend_system_design_interview_guide.md)
+- [Fraud Detection System Design](./fraud_detection.md)
+- [Backend and System Design for AI](./intro_backend_ai_system_design.md)
+- [ML System Design Patterns — 2026 Production Guide](./ml_system_design_patterns.md)
+- [Recommendation System Design](./recommendation_system.md)
+
+---
+
 ## References
 
 - [Designing Machine Learning Systems — Chip Huyen (O'Reilly)](https://www.oreilly.com/library/view/designing-machine-learning/9781098107956/)


### PR DESCRIPTION
Follow-up to #19. Fills four more confirmed gaps and fixes navigation that the previous round left incomplete.

## What

### Four new guides

| File | Covers |
|---|---|
| `deep_learning/intro_sequence_models.md` | RNN/LSTM/GRU internals, why additive gating fixes vanishing gradients, seq2seq and its fixed-context bottleneck, the attention variants that followed, RNN vs transformer tradeoffs, and the padding/packing bugs that silently cap accuracy |
| `ai_genai/intro_context_engineering.md` | Context budgets, ordering and the lost-in-the-middle effect, prefix stability for prompt caching, layered conversation memory, compaction, agent context growth, and context-rot failure modes |
| `mlops/intro_cicd_for_ml.md` | How ML CI/CD differs from software CI/CD, the ML testing pyramid, model registry and promotion gates, shadow → canary → A/B deployment, complete rollback, continuous training, maturity levels |
| `docs/take-home-projects.md` | What reviewers actually score, time budgeting, repository structure, the README as the deliverable, take-home types, and the follow-up presentation round |

Each follows the house format from `CONTRIBUTING.md`: TOC, code, comparison tables, Interview Q&A, Common Pitfalls, Related Topics.

### Navigation fix (a gap from #19)

The previous round wired new files into `index.html` and the root README but **not** the per-directory READMEs — so `intro_model_evaluation`, `intro_ensemble_methods`, `intro_neural_network_training` and `ml_coding_challenges` were unreachable from their own track pages.

Added a **"Guides in This Track"** index to seven sub-READMEs (`classical_ml`, `coding_challenges`, `deep_learning`, `frameworks`, `mlops`, `project_setup`, `system_design`), following the pattern `cloud_ml/README.md` already used. Labels are generated from each guide's own H1, so they stay accurate.

### Duplicate feature store guides

`intro_feature_store.md` and `intro_feature_stores.md` overlap, and only the plural was in the nav. Non-destructive fix: cross-linked them with a note on what each emphasizes (motivation + tool comparison + Feast walkthrough vs point-in-time correctness + when-to-adopt + pitfalls), and pointed the mlops README at both. **A full merge of the pair is left to you** — it means deleting content, so it isn't mine to decide.

## Why

Sequence models, context engineering, and CI/CD for ML had no owner file — each was mentioned in passing across several guides but never covered directly. The take-home round is listed as an interview stage in the roadmap with nothing behind it. And the sub-README gap meant a third of last round's work was invisible to anyone browsing a track directory rather than the site.

## Verification

- **709** relative links resolve (0 broken)
- All **110** `index.html` registry paths exist
- No dead TOC anchors in the new guides
- **14** Python blocks and **2** YAML blocks parse (`ast.parse` / `yaml.safe_load`)
- `index.html` scripts pass `node --check`
- Orphan check: every guide is reachable from the registry or a README index
